### PR TITLE
Update node.go

### DIFF
--- a/diagram/node.go
+++ b/diagram/node.go
@@ -137,7 +137,7 @@ func DefaultNodeOptions(opts ...NodeOption) NodeOptions {
 		Font: Font{
 			Name:  "Sans-Serif",
 			Size:  13,
-			Color: "#@D3436",
+			Color: "#2D3436",
 		},
 		Attributes: make(map[string]string),
 	}


### PR DESCRIPTION
Fix typo in a Color definition.

Closes #3 .