### PR TITLE
Add NewDiagram to allow creating new diagrams from plain diagram.Options

### DIFF
--- a/diagram/diagram.go
+++ b/diagram/diagram.go
@@ -24,9 +24,7 @@ type Diagram struct {
 
 func New(opts ...Option) (*Diagram, error) {
 	options := DefaultOptions(opts...)
-	g := graphviz.NewEscape()
-	g.SetName("root")
-	g.SetDir(true)
+	g := newGraphviz()
 
 	for k, v := range options.attrs() {
 		if err := g.AddAttr("root", k, v); err != nil {
@@ -34,15 +32,27 @@ func New(opts ...Option) (*Diagram, error) {
 		}
 	}
 
-	return new(g, options), nil
+	return newDiagram(g, options), nil
 }
 
-func new(g *graphviz.Escape, options Options) *Diagram {
+func NewDiagram(options Options) (*Diagram, error) {
+	return newDiagram(newGraphviz(), options), nil
+}
+
+func newDiagram(g *graphviz.Escape, options Options) *Diagram {
 	return &Diagram{
 		g:       g,
 		options: options,
 		root:    newGroup("root", 0, nil),
 	}
+}
+
+func newGraphviz() *graphviz.Escape {
+	g := graphviz.NewEscape()
+	g.SetName("root")
+	g.SetDir(true)
+
+	return g
 }
 
 func (d *Diagram) Nodes() []*Node {


### PR DESCRIPTION
This PR makes it possible to create a diagram from a plain `*diagram.Options` struct.

The motivation behind this PR is that one cannot set the `Name` field of a diagram's options.  
While the preferred way of creating a diagram seems to be passing `Option` functions that override the default ones, allowing the user to simply pass the object is much more flexible.  
It is also not possible to create a `Name` function that would set that field, because the `diagram` package already contains such a function that sets a node's name.

Maybe all node-related functions should be moved to a separate package to avoid such collisions?