### PR TITLE
Fix default values for groups and nodes.

### DIFF
--- a/diagram/node.go
+++ b/diagram/node.go
@@ -126,7 +126,7 @@ type OptionSet []NodeOption
 func DefaultNodeOptions(opts ...NodeOption) NodeOptions {
 	nopts := NodeOptions{
 		Name:          "node",
-		Label:         "node",
+		Label:         "",
 		Shape:         "box",
 		Style:         "rounded",
 		FixedSize:     true,

--- a/diagram/options.go
+++ b/diagram/options.go
@@ -37,7 +37,7 @@ func (o Options) attrs() map[string]string {
 		m[k] = v
 	}
 
-	return m
+	return trimAttrs(m)
 }
 
 type Option func(*Options)


### PR DESCRIPTION
This addresses https://github.com/blushft/go-diagrams/issues/12

For groups, this strips the label if it's empty. For nodes, this uses
empty string as the default label which also results in the label
attribute being stripped if empty.

This is necessary because otherwise the default values don't lead to
valid graphviz code.