### PR TITLE
Use MkdirAll to create outdir

### DIFF
--- a/diagram/diagram.go
+++ b/diagram/diagram.go
@@ -88,7 +88,7 @@ func (d *Diagram) Render() error {
 
 func (d *Diagram) render() error {
 	outdir := d.options.Name
-	if err := os.Mkdir(outdir, os.ModePerm); err != nil {
+	if err := os.MkdirAll(outdir, os.ModePerm); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Possibly fixes #14

This would also make it possible to generate more than one output file with a single `go build` command