### PR TITLE
 feat: sorted images for consistent generation

### DIFF
--- a/cmd/gen/main.go
+++ b/cmd/gen/main.go
@@ -4,6 +4,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/dave/jennifer/jen"
@@ -142,7 +143,22 @@ func genContainer(root, pName, pPath, name string, imgs map[string]string) error
 		},
 	)
 
-	for img, imgPath := range imgs {
+        // sorted keys for consistent generation
+        type kv struct {
+            Key   string
+            Value string
+        }
+        sorted := make([]kv, 0, len(imgs))
+        for k, v := range imgs {
+            sorted = append(sorted, kv{k, v})
+        }
+        sort.Slice(sorted, func(i, j int) bool {
+            return sorted[i].Value < sorted[j].Value
+        })
+
+	for _, p := range sorted {
+		img := p.Key
+                imgPath := p.Value
 		method := strcase.ToCamel(img)
 		f.Func().Params(jen.Id("c").Op("*").Id(cname)).
 			Id(method).

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,10 @@
 module github.com/blushft/go-diagrams
 
-go 1.14
+go 1.23
+
+toolchain go1.24.5
 
 require (
-	github.com/UnnoTed/fileb0x v1.1.4 // indirect
 	github.com/awalterschulze/gographviz v0.0.0-20200901124122-0eecad45bd71
 	github.com/dave/jennifer v1.4.1
 	github.com/davecgh/go-spew v1.1.1
@@ -11,6 +12,41 @@ require (
 	github.com/iancoleman/strcase v0.1.1
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.6.1
-	golang.org/x/exp v0.0.0-20200908183739-ae8ad444f925 // indirect
 	golang.org/x/net v0.0.0-20190620200207-3b0461eec859
+)
+
+require (
+	dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9 // indirect
+	github.com/BurntSushi/toml v0.3.1 // indirect
+	github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802 // indirect
+	github.com/UnnoTed/fileb0x v1.1.4 // indirect
+	github.com/bmatcuk/doublestar v1.1.1 // indirect
+	github.com/dgrijalva/jwt-go v3.2.0+incompatible // indirect
+	github.com/gizak/termui/v3 v3.1.0 // indirect
+	github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4 // indirect
+	github.com/karrick/godirwalk v1.7.8 // indirect
+	github.com/labstack/echo v3.2.1+incompatible // indirect
+	github.com/labstack/gommon v0.2.7 // indirect
+	github.com/mattn/go-colorable v0.0.9 // indirect
+	github.com/mattn/go-isatty v0.0.4 // indirect
+	github.com/mattn/go-runewidth v0.0.3 // indirect
+	github.com/mitchellh/go-wordwrap v1.0.0 // indirect
+	github.com/nsf/termbox-go v0.0.0-20190121233118-02980233997d // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/stretchr/objx v0.1.0 // indirect
+	github.com/valyala/bytebufferpool v1.0.0 // indirect
+	github.com/valyala/fasttemplate v0.0.0-20170224212429-dcecefd839c4 // indirect
+	golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550 // indirect
+	golang.org/x/exp v0.0.0-20200908183739-ae8ad444f925 // indirect
+	golang.org/x/image v0.0.0-20190802002840-cff245a6509b // indirect
+	golang.org/x/mobile v0.0.0-20190719004257-d2bd2a29d028 // indirect
+	golang.org/x/mod v0.3.1-0.20200828183125-ce943fd02449 // indirect
+	golang.org/x/sync v0.0.0-20190423024810-112230192c58 // indirect
+	golang.org/x/sys v0.0.0-20191001151750-bb3f8db39f24 // indirect
+	golang.org/x/text v0.3.0 // indirect
+	golang.org/x/tools v0.0.0-20200207183749-b753a1ba74fa // indirect
+	golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898 // indirect
+	gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 // indirect
+	gopkg.in/yaml.v2 v2.2.1 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 )

--- a/nodes/alibabacloud/application.go
+++ b/nodes/alibabacloud/application.go
@@ -12,38 +12,13 @@ var Application = &applicationContainer{
 	path: "assets/alibabacloud/application",
 }
 
-func (c *applicationContainer) Yida(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/alibabacloud/application/yida.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
 func (c *applicationContainer) ApiGateway(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/alibabacloud/application/api-gateway.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }
 
-func (c *applicationContainer) PerformanceTestingService(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/alibabacloud/application/performance-testing-service.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *applicationContainer) CodePipeline(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/alibabacloud/application/code-pipeline.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *applicationContainer) DirectMail(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/alibabacloud/application/direct-mail.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *applicationContainer) MessageNotificationService(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/alibabacloud/application/message-notification-service.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *applicationContainer) RdCloud(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/alibabacloud/application/rd-cloud.png")}, c.opts, opts)
+func (c *applicationContainer) BeeBot(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/alibabacloud/application/bee-bot.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }
 
@@ -57,6 +32,26 @@ func (c *applicationContainer) CloudCallCenter(opts ...diagram.NodeOption) *diag
 	return diagram.NewNode(nopts...)
 }
 
+func (c *applicationContainer) CodePipeline(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/alibabacloud/application/code-pipeline.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *applicationContainer) DirectMail(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/alibabacloud/application/direct-mail.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *applicationContainer) LogService(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/alibabacloud/application/log-service.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *applicationContainer) MessageNotificationService(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/alibabacloud/application/message-notification-service.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
 func (c *applicationContainer) NodeJsPerformancePlatform(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/alibabacloud/application/node-js-performance-platform.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
@@ -67,17 +62,22 @@ func (c *applicationContainer) OpenSearch(opts ...diagram.NodeOption) *diagram.N
 	return diagram.NewNode(nopts...)
 }
 
+func (c *applicationContainer) PerformanceTestingService(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/alibabacloud/application/performance-testing-service.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *applicationContainer) RdCloud(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/alibabacloud/application/rd-cloud.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
 func (c *applicationContainer) SmartConversationAnalysis(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/alibabacloud/application/smart-conversation-analysis.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }
 
-func (c *applicationContainer) BeeBot(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/alibabacloud/application/bee-bot.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *applicationContainer) LogService(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/alibabacloud/application/log-service.png")}, c.opts, opts)
+func (c *applicationContainer) Yida(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/alibabacloud/application/yida.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }

--- a/nodes/alibabacloud/compute.go
+++ b/nodes/alibabacloud/compute.go
@@ -17,8 +17,18 @@ func (c *computeContainer) AutoScaling(opts ...diagram.NodeOption) *diagram.Node
 	return diagram.NewNode(nopts...)
 }
 
+func (c *computeContainer) BatchCompute(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/alibabacloud/compute/batch-compute.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
 func (c *computeContainer) ContainerRegistry(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/alibabacloud/compute/container-registry.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *computeContainer) ContainerService(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/alibabacloud/compute/container-service.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }
 
@@ -27,28 +37,8 @@ func (c *computeContainer) ElasticComputeService(opts ...diagram.NodeOption) *di
 	return diagram.NewNode(nopts...)
 }
 
-func (c *computeContainer) FunctionCompute(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/alibabacloud/compute/function-compute.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *computeContainer) OperationOrchestrationService(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/alibabacloud/compute/operation-orchestration-service.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *computeContainer) ServerLoadBalancer(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/alibabacloud/compute/server-load-balancer.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *computeContainer) ServerlessAppEngine(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/alibabacloud/compute/serverless-app-engine.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *computeContainer) ContainerService(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/alibabacloud/compute/container-service.png")}, c.opts, opts)
+func (c *computeContainer) ElasticContainerInstance(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/alibabacloud/compute/elastic-container-instance.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }
 
@@ -62,18 +52,28 @@ func (c *computeContainer) ElasticSearch(opts ...diagram.NodeOption) *diagram.No
 	return diagram.NewNode(nopts...)
 }
 
+func (c *computeContainer) FunctionCompute(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/alibabacloud/compute/function-compute.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *computeContainer) OperationOrchestrationService(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/alibabacloud/compute/operation-orchestration-service.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
 func (c *computeContainer) ResourceOrchestrationService(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/alibabacloud/compute/resource-orchestration-service.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }
 
-func (c *computeContainer) BatchCompute(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/alibabacloud/compute/batch-compute.png")}, c.opts, opts)
+func (c *computeContainer) ServerLoadBalancer(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/alibabacloud/compute/server-load-balancer.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }
 
-func (c *computeContainer) ElasticContainerInstance(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/alibabacloud/compute/elastic-container-instance.png")}, c.opts, opts)
+func (c *computeContainer) ServerlessAppEngine(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/alibabacloud/compute/serverless-app-engine.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }
 

--- a/nodes/alibabacloud/database.go
+++ b/nodes/alibabacloud/database.go
@@ -12,41 +12,6 @@ var Database = &databaseContainer{
 	path: "assets/alibabacloud/database",
 }
 
-func (c *databaseContainer) DatabaseBackupService(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/alibabacloud/database/database-backup-service.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *databaseContainer) RelationalDatabaseService(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/alibabacloud/database/relational-database-service.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *databaseContainer) ApsaradbMongodb(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/alibabacloud/database/apsaradb-mongodb.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *databaseContainer) ApsaradbRedis(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/alibabacloud/database/apsaradb-redis.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *databaseContainer) DataManagementService(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/alibabacloud/database/data-management-service.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *databaseContainer) DataTransmissionService(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/alibabacloud/database/data-transmission-service.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *databaseContainer) GraphDatabaseService(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/alibabacloud/database/graph-database-service.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
 func (c *databaseContainer) ApsaradbCassandra(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/alibabacloud/database/apsaradb-cassandra.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
@@ -57,8 +22,13 @@ func (c *databaseContainer) ApsaradbHbase(opts ...diagram.NodeOption) *diagram.N
 	return diagram.NewNode(nopts...)
 }
 
-func (c *databaseContainer) ApsaradbPpas(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/alibabacloud/database/apsaradb-ppas.png")}, c.opts, opts)
+func (c *databaseContainer) ApsaradbMemcache(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/alibabacloud/database/apsaradb-memcache.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *databaseContainer) ApsaradbMongodb(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/alibabacloud/database/apsaradb-mongodb.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }
 
@@ -72,8 +42,38 @@ func (c *databaseContainer) ApsaradbPolardb(opts ...diagram.NodeOption) *diagram
 	return diagram.NewNode(nopts...)
 }
 
-func (c *databaseContainer) HybriddbForMysql(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/alibabacloud/database/hybriddb-for-mysql.png")}, c.opts, opts)
+func (c *databaseContainer) ApsaradbPostgresql(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/alibabacloud/database/apsaradb-postgresql.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *databaseContainer) ApsaradbPpas(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/alibabacloud/database/apsaradb-ppas.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *databaseContainer) ApsaradbRedis(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/alibabacloud/database/apsaradb-redis.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *databaseContainer) ApsaradbSqlserver(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/alibabacloud/database/apsaradb-sqlserver.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *databaseContainer) DataManagementService(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/alibabacloud/database/data-management-service.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *databaseContainer) DataTransmissionService(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/alibabacloud/database/data-transmission-service.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *databaseContainer) DatabaseBackupService(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/alibabacloud/database/database-backup-service.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }
 
@@ -82,17 +82,17 @@ func (c *databaseContainer) DisributeRelationalDatabaseService(opts ...diagram.N
 	return diagram.NewNode(nopts...)
 }
 
-func (c *databaseContainer) ApsaradbMemcache(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/alibabacloud/database/apsaradb-memcache.png")}, c.opts, opts)
+func (c *databaseContainer) GraphDatabaseService(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/alibabacloud/database/graph-database-service.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }
 
-func (c *databaseContainer) ApsaradbPostgresql(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/alibabacloud/database/apsaradb-postgresql.png")}, c.opts, opts)
+func (c *databaseContainer) HybriddbForMysql(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/alibabacloud/database/hybriddb-for-mysql.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }
 
-func (c *databaseContainer) ApsaradbSqlserver(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/alibabacloud/database/apsaradb-sqlserver.png")}, c.opts, opts)
+func (c *databaseContainer) RelationalDatabaseService(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/alibabacloud/database/relational-database-service.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }

--- a/nodes/alibabacloud/network.go
+++ b/nodes/alibabacloud/network.go
@@ -12,31 +12,6 @@ var Network = &networkContainer{
 	path: "assets/alibabacloud/network",
 }
 
-func (c *networkContainer) ElasticIpAddress(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/alibabacloud/network/elastic-ip-address.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *networkContainer) ServerLoadBalancer(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/alibabacloud/network/server-load-balancer.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *networkContainer) VirtualPrivateCloud(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/alibabacloud/network/virtual-private-cloud.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *networkContainer) VpnGateway(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/alibabacloud/network/vpn-gateway.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *networkContainer) SmartAccessGateway(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/alibabacloud/network/smart-access-gateway.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
 func (c *networkContainer) Cdn(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/alibabacloud/network/cdn.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
@@ -47,6 +22,11 @@ func (c *networkContainer) CloudEnterpriseNetwork(opts ...diagram.NodeOption) *d
 	return diagram.NewNode(nopts...)
 }
 
+func (c *networkContainer) ElasticIpAddress(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/alibabacloud/network/elastic-ip-address.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
 func (c *networkContainer) ExpressConnect(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/alibabacloud/network/express-connect.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
@@ -54,5 +34,25 @@ func (c *networkContainer) ExpressConnect(opts ...diagram.NodeOption) *diagram.N
 
 func (c *networkContainer) NatGateway(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/alibabacloud/network/nat-gateway.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *networkContainer) ServerLoadBalancer(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/alibabacloud/network/server-load-balancer.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *networkContainer) SmartAccessGateway(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/alibabacloud/network/smart-access-gateway.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *networkContainer) VirtualPrivateCloud(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/alibabacloud/network/virtual-private-cloud.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *networkContainer) VpnGateway(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/alibabacloud/network/vpn-gateway.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }

--- a/nodes/alibabacloud/security.go
+++ b/nodes/alibabacloud/security.go
@@ -17,8 +17,18 @@ func (c *securityContainer) AntiBotService(opts ...diagram.NodeOption) *diagram.
 	return diagram.NewNode(nopts...)
 }
 
+func (c *securityContainer) AntiDdosBasic(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/alibabacloud/security/anti-ddos-basic.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
 func (c *securityContainer) AntiDdosPro(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/alibabacloud/security/anti-ddos-pro.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *securityContainer) AntifraudService(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/alibabacloud/security/antifraud-service.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }
 
@@ -32,26 +42,6 @@ func (c *securityContainer) CloudFirewall(opts ...diagram.NodeOption) *diagram.N
 	return diagram.NewNode(nopts...)
 }
 
-func (c *securityContainer) CrowdsourcedSecurityTesting(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/alibabacloud/security/crowdsourced-security-testing.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *securityContainer) GameShield(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/alibabacloud/security/game-shield.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *securityContainer) SecurityCenter(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/alibabacloud/security/security-center.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *securityContainer) AntifraudService(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/alibabacloud/security/antifraud-service.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
 func (c *securityContainer) CloudSecurityScanner(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/alibabacloud/security/cloud-security-scanner.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
@@ -62,18 +52,23 @@ func (c *securityContainer) ContentModeration(opts ...diagram.NodeOption) *diagr
 	return diagram.NewNode(nopts...)
 }
 
-func (c *securityContainer) DbAudit(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/alibabacloud/security/db-audit.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *securityContainer) AntiDdosBasic(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/alibabacloud/security/anti-ddos-basic.png")}, c.opts, opts)
+func (c *securityContainer) CrowdsourcedSecurityTesting(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/alibabacloud/security/crowdsourced-security-testing.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }
 
 func (c *securityContainer) DataEncryptionService(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/alibabacloud/security/data-encryption-service.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *securityContainer) DbAudit(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/alibabacloud/security/db-audit.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *securityContainer) GameShield(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/alibabacloud/security/game-shield.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }
 
@@ -84,6 +79,11 @@ func (c *securityContainer) IdVerification(opts ...diagram.NodeOption) *diagram.
 
 func (c *securityContainer) ManagedSecurityService(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/alibabacloud/security/managed-security-service.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *securityContainer) SecurityCenter(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/alibabacloud/security/security-center.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }
 

--- a/nodes/alibabacloud/storage.go
+++ b/nodes/alibabacloud/storage.go
@@ -12,6 +12,16 @@ var Storage = &storageContainer{
 	path: "assets/alibabacloud/storage",
 }
 
+func (c *storageContainer) CloudStorageGateway(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/alibabacloud/storage/cloud-storage-gateway.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *storageContainer) FileStorageHdfs(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/alibabacloud/storage/file-storage-hdfs.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
 func (c *storageContainer) FileStorageNas(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/alibabacloud/storage/file-storage-nas.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
@@ -39,15 +49,5 @@ func (c *storageContainer) ObjectStorageService(opts ...diagram.NodeOption) *dia
 
 func (c *storageContainer) ObjectTableStore(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/alibabacloud/storage/object-table-store.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *storageContainer) CloudStorageGateway(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/alibabacloud/storage/cloud-storage-gateway.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *storageContainer) FileStorageHdfs(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/alibabacloud/storage/file-storage-hdfs.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }

--- a/nodes/apps/analytics.go
+++ b/nodes/apps/analytics.go
@@ -12,8 +12,23 @@ var Analytics = &analyticsContainer{
 	path: "assets/apps/analytics",
 }
 
+func (c *analyticsContainer) Beam(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/apps/analytics/beam.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *analyticsContainer) Databricks(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/apps/analytics/databricks.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
 func (c *analyticsContainer) Dbt(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/apps/analytics/dbt.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *analyticsContainer) Flink(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/apps/analytics/flink.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }
 
@@ -32,8 +47,13 @@ func (c *analyticsContainer) Metabase(opts ...diagram.NodeOption) *diagram.Node 
 	return diagram.NewNode(nopts...)
 }
 
-func (c *analyticsContainer) Tableau(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/apps/analytics/tableau.png")}, c.opts, opts)
+func (c *analyticsContainer) Norikra(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/apps/analytics/norikra.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *analyticsContainer) Singer(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/apps/analytics/singer.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }
 
@@ -47,27 +67,7 @@ func (c *analyticsContainer) Storm(opts ...diagram.NodeOption) *diagram.Node {
 	return diagram.NewNode(nopts...)
 }
 
-func (c *analyticsContainer) Beam(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/apps/analytics/beam.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *analyticsContainer) Databricks(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/apps/analytics/databricks.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *analyticsContainer) Flink(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/apps/analytics/flink.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *analyticsContainer) Norikra(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/apps/analytics/norikra.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *analyticsContainer) Singer(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/apps/analytics/singer.png")}, c.opts, opts)
+func (c *analyticsContainer) Tableau(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/apps/analytics/tableau.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }

--- a/nodes/apps/ci.go
+++ b/nodes/apps/ci.go
@@ -12,18 +12,8 @@ var Ci = &ciContainer{
 	path: "assets/apps/ci",
 }
 
-func (c *ciContainer) Teamcity(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/apps/ci/teamcity.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *ciContainer) Travisci(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/apps/ci/travisci.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *ciContainer) Zuulci(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/apps/ci/zuulci.png")}, c.opts, opts)
+func (c *ciContainer) Bitbucket(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/apps/ci/bitbucket.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }
 
@@ -57,7 +47,17 @@ func (c *ciContainer) Screwdrivercd(opts ...diagram.NodeOption) *diagram.Node {
 	return diagram.NewNode(nopts...)
 }
 
-func (c *ciContainer) Bitbucket(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/apps/ci/bitbucket.png")}, c.opts, opts)
+func (c *ciContainer) Teamcity(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/apps/ci/teamcity.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *ciContainer) Travisci(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/apps/ci/travisci.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *ciContainer) Zuulci(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/apps/ci/zuulci.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }

--- a/nodes/apps/database.go
+++ b/nodes/apps/database.go
@@ -12,18 +12,18 @@ var Database = &databaseContainer{
 	path: "assets/apps/database",
 }
 
-func (c *databaseContainer) Mariadb(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/apps/database/mariadb.png")}, c.opts, opts)
+func (c *databaseContainer) Cassandra(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/apps/database/cassandra.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }
 
-func (c *databaseContainer) Mssql(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/apps/database/mssql.png")}, c.opts, opts)
+func (c *databaseContainer) Clickhouse(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/apps/database/clickhouse.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }
 
-func (c *databaseContainer) Oracle(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/apps/database/oracle.png")}, c.opts, opts)
+func (c *databaseContainer) Cockroachdb(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/apps/database/cockroachdb.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }
 
@@ -32,38 +32,18 @@ func (c *databaseContainer) Couchbase(opts ...diagram.NodeOption) *diagram.Node 
 	return diagram.NewNode(nopts...)
 }
 
+func (c *databaseContainer) Couchdb(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/apps/database/couchdb.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *databaseContainer) Dgraph(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/apps/database/dgraph.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
 func (c *databaseContainer) Druid(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/apps/database/druid.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *databaseContainer) Janusgraph(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/apps/database/janusgraph.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *databaseContainer) Mongodb(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/apps/database/mongodb.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *databaseContainer) Neo4J(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/apps/database/neo4j.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *databaseContainer) Postgresql(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/apps/database/postgresql.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *databaseContainer) Cassandra(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/apps/database/cassandra.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *databaseContainer) Cockroachdb(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/apps/database/cockroachdb.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }
 
@@ -77,27 +57,47 @@ func (c *databaseContainer) Influxdb(opts ...diagram.NodeOption) *diagram.Node {
 	return diagram.NewNode(nopts...)
 }
 
+func (c *databaseContainer) Janusgraph(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/apps/database/janusgraph.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *databaseContainer) Mariadb(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/apps/database/mariadb.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *databaseContainer) Mongodb(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/apps/database/mongodb.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *databaseContainer) Mssql(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/apps/database/mssql.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
 func (c *databaseContainer) Mysql(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/apps/database/mysql.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }
 
+func (c *databaseContainer) Neo4J(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/apps/database/neo4j.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *databaseContainer) Oracle(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/apps/database/oracle.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *databaseContainer) Postgresql(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/apps/database/postgresql.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
 func (c *databaseContainer) Scylla(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/apps/database/scylla.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *databaseContainer) Clickhouse(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/apps/database/clickhouse.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *databaseContainer) Couchdb(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/apps/database/couchdb.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *databaseContainer) Dgraph(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/apps/database/dgraph.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }

--- a/nodes/apps/inmemory.go
+++ b/nodes/apps/inmemory.go
@@ -12,6 +12,11 @@ var Inmemory = &inmemoryContainer{
 	path: "assets/apps/inmemory",
 }
 
+func (c *inmemoryContainer) Aerospike(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/apps/inmemory/aerospike.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
 func (c *inmemoryContainer) Hazelcast(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/apps/inmemory/hazelcast.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
@@ -24,10 +29,5 @@ func (c *inmemoryContainer) Memcached(opts ...diagram.NodeOption) *diagram.Node 
 
 func (c *inmemoryContainer) Redis(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/apps/inmemory/redis.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *inmemoryContainer) Aerospike(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/apps/inmemory/aerospike.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }

--- a/nodes/apps/logging.go
+++ b/nodes/apps/logging.go
@@ -12,6 +12,16 @@ var Logging = &loggingContainer{
 	path: "assets/apps/logging",
 }
 
+func (c *loggingContainer) Fluentbit(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/apps/logging/fluentbit.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *loggingContainer) Fluentd(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/apps/logging/fluentd.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
 func (c *loggingContainer) Graylog(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/apps/logging/graylog.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
@@ -29,15 +39,5 @@ func (c *loggingContainer) Rsyslog(opts ...diagram.NodeOption) *diagram.Node {
 
 func (c *loggingContainer) SyslogNg(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/apps/logging/syslog-ng.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *loggingContainer) Fluentbit(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/apps/logging/fluentbit.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *loggingContainer) Fluentd(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/apps/logging/fluentd.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }

--- a/nodes/apps/monitoring.go
+++ b/nodes/apps/monitoring.go
@@ -12,11 +12,6 @@ var Monitoring = &monitoringContainer{
 	path: "assets/apps/monitoring",
 }
 
-func (c *monitoringContainer) Thanos(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/apps/monitoring/thanos.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
 func (c *monitoringContainer) Datadog(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/apps/monitoring/datadog.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
@@ -44,5 +39,10 @@ func (c *monitoringContainer) Sentry(opts ...diagram.NodeOption) *diagram.Node {
 
 func (c *monitoringContainer) Splunk(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/apps/monitoring/splunk.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *monitoringContainer) Thanos(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/apps/monitoring/thanos.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }

--- a/nodes/apps/network.go
+++ b/nodes/apps/network.go
@@ -12,53 +12,23 @@ var Network = &networkContainer{
 	path: "assets/apps/network",
 }
 
-func (c *networkContainer) Internet(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/apps/network/internet.png")}, c.opts, opts)
+func (c *networkContainer) Apache(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/apps/network/apache.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }
 
-func (c *networkContainer) Istio(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/apps/network/istio.png")}, c.opts, opts)
+func (c *networkContainer) Caddy(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/apps/network/caddy.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }
 
-func (c *networkContainer) Linkerd(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/apps/network/linkerd.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *networkContainer) Ocelot(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/apps/network/ocelot.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *networkContainer) Tomcat(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/apps/network/tomcat.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *networkContainer) Vyos(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/apps/network/vyos.png")}, c.opts, opts)
+func (c *networkContainer) Consul(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/apps/network/consul.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }
 
 func (c *networkContainer) Envoy(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/apps/network/envoy.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *networkContainer) Nginx(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/apps/network/nginx.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *networkContainer) Pfsense(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/apps/network/pfsense.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *networkContainer) Apache(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/apps/network/apache.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }
 
@@ -72,13 +42,13 @@ func (c *networkContainer) Haproxy(opts ...diagram.NodeOption) *diagram.Node {
 	return diagram.NewNode(nopts...)
 }
 
-func (c *networkContainer) Pomerium(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/apps/network/pomerium.png")}, c.opts, opts)
+func (c *networkContainer) Internet(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/apps/network/internet.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }
 
-func (c *networkContainer) Caddy(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/apps/network/caddy.png")}, c.opts, opts)
+func (c *networkContainer) Istio(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/apps/network/istio.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }
 
@@ -87,17 +57,47 @@ func (c *networkContainer) Kong(opts ...diagram.NodeOption) *diagram.Node {
 	return diagram.NewNode(nopts...)
 }
 
+func (c *networkContainer) Linkerd(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/apps/network/linkerd.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *networkContainer) Nginx(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/apps/network/nginx.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *networkContainer) Ocelot(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/apps/network/ocelot.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *networkContainer) Pfsense(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/apps/network/pfsense.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *networkContainer) Pomerium(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/apps/network/pomerium.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *networkContainer) Tomcat(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/apps/network/tomcat.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
 func (c *networkContainer) Traefik(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/apps/network/traefik.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }
 
-func (c *networkContainer) Zookeeper(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/apps/network/zookeeper.png")}, c.opts, opts)
+func (c *networkContainer) Vyos(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/apps/network/vyos.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }
 
-func (c *networkContainer) Consul(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/apps/network/consul.png")}, c.opts, opts)
+func (c *networkContainer) Zookeeper(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/apps/network/zookeeper.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }

--- a/nodes/apps/workflow.go
+++ b/nodes/apps/workflow.go
@@ -12,6 +12,11 @@ var Workflow = &workflowContainer{
 	path: "assets/apps/workflow",
 }
 
+func (c *workflowContainer) Airflow(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/apps/workflow/airflow.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
 func (c *workflowContainer) Digdag(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/apps/workflow/digdag.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
@@ -24,10 +29,5 @@ func (c *workflowContainer) Kubeflow(opts ...diagram.NodeOption) *diagram.Node {
 
 func (c *workflowContainer) Nifi(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/apps/workflow/nifi.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *workflowContainer) Airflow(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/apps/workflow/airflow.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }

--- a/nodes/aws/analytics.go
+++ b/nodes/aws/analytics.go
@@ -17,56 +17,6 @@ func (c *analyticsContainer) Analytics(opts ...diagram.NodeOption) *diagram.Node
 	return diagram.NewNode(nopts...)
 }
 
-func (c *analyticsContainer) Emr(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/analytics/emr.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *analyticsContainer) GlueCrawlers(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/analytics/glue-crawlers.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *analyticsContainer) KinesisDataAnalytics(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/analytics/kinesis-data-analytics.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *analyticsContainer) KinesisVideoStreams(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/analytics/kinesis-video-streams.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *analyticsContainer) Kinesis(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/analytics/kinesis.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *analyticsContainer) Quicksight(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/analytics/quicksight.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *analyticsContainer) ElasticsearchService(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/analytics/elasticsearch-service.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *analyticsContainer) GlueDataCatalog(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/analytics/glue-data-catalog.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *analyticsContainer) RedshiftDenseStorageNode(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/analytics/redshift-dense-storage-node.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *analyticsContainer) Redshift(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/analytics/redshift.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
 func (c *analyticsContainer) Athena(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/analytics/athena.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
@@ -74,21 +24,6 @@ func (c *analyticsContainer) Athena(opts ...diagram.NodeOption) *diagram.Node {
 
 func (c *analyticsContainer) CloudsearchSearchDocuments(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/analytics/cloudsearch-search-documents.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *analyticsContainer) EmrHdfsCluster(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/analytics/emr-hdfs-cluster.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *analyticsContainer) LakeFormation(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/analytics/lake-formation.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *analyticsContainer) ManagedStreamingForKafka(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/analytics/managed-streaming-for-kafka.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }
 
@@ -102,13 +37,43 @@ func (c *analyticsContainer) DataPipeline(opts ...diagram.NodeOption) *diagram.N
 	return diagram.NewNode(nopts...)
 }
 
+func (c *analyticsContainer) ElasticsearchService(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/analytics/elasticsearch-service.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
 func (c *analyticsContainer) EmrCluster(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/analytics/emr-cluster.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }
 
+func (c *analyticsContainer) EmrHdfsCluster(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/analytics/emr-hdfs-cluster.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *analyticsContainer) Emr(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/analytics/emr.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *analyticsContainer) GlueCrawlers(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/analytics/glue-crawlers.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *analyticsContainer) GlueDataCatalog(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/analytics/glue-data-catalog.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
 func (c *analyticsContainer) Glue(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/analytics/glue.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *analyticsContainer) KinesisDataAnalytics(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/analytics/kinesis-data-analytics.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }
 
@@ -122,7 +87,42 @@ func (c *analyticsContainer) KinesisDataStreams(opts ...diagram.NodeOption) *dia
 	return diagram.NewNode(nopts...)
 }
 
+func (c *analyticsContainer) KinesisVideoStreams(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/analytics/kinesis-video-streams.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *analyticsContainer) Kinesis(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/analytics/kinesis.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *analyticsContainer) LakeFormation(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/analytics/lake-formation.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *analyticsContainer) ManagedStreamingForKafka(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/analytics/managed-streaming-for-kafka.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *analyticsContainer) Quicksight(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/analytics/quicksight.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
 func (c *analyticsContainer) RedshiftDenseComputeNode(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/analytics/redshift-dense-compute-node.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *analyticsContainer) RedshiftDenseStorageNode(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/analytics/redshift-dense-storage-node.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *analyticsContainer) Redshift(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/analytics/redshift.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }

--- a/nodes/aws/compute.go
+++ b/nodes/aws/compute.go
@@ -12,168 +12,8 @@ var Compute = &computeContainer{
 	path: "assets/aws/compute",
 }
 
-func (c *computeContainer) OutpostsRounded(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/compute/outposts-rounded.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *computeContainer) ThinkboxSequoia(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/compute/thinkbox-sequoia.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *computeContainer) ElasticBeanstalk(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/compute/elastic-beanstalk.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *computeContainer) FargateRounded(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/compute/fargate-rounded.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *computeContainer) LambdaRounded(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/compute/lambda-rounded.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *computeContainer) ElasticBeanstalkRounded(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/compute/elastic-beanstalk-rounded.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *computeContainer) ThinkboxSequoiaRounded(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/compute/thinkbox-sequoia-rounded.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *computeContainer) ThinkboxStokeRounded(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/compute/thinkbox-stoke-rounded.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *computeContainer) ThinkboxXmeshRounded(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/compute/thinkbox-xmesh-rounded.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
 func (c *computeContainer) ApplicationAutoScalingRounded(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/compute/application-auto-scaling-rounded.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *computeContainer) Ec2ContainerRegistry(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/compute/ec2-container-registry.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *computeContainer) Fargate(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/compute/fargate.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *computeContainer) Outposts(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/compute/outposts.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *computeContainer) ThinkboxDraftRounded(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/compute/thinkbox-draft-rounded.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *computeContainer) VmwareCloudOnAwsRounded(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/compute/vmware-cloud-on-aws-rounded.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *computeContainer) BatchRounded(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/compute/batch-rounded.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *computeContainer) ElasticKubernetesServiceRounded(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/compute/elastic-kubernetes-service-rounded.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *computeContainer) Lambda(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/compute/lambda.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *computeContainer) ServerlessApplicationRepositoryRounded(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/compute/serverless-application-repository-rounded.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *computeContainer) ThinkboxDeadlineRounded(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/compute/thinkbox-deadline-rounded.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *computeContainer) ThinkboxDeadline(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/compute/thinkbox-deadline.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *computeContainer) ThinkboxStoke(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/compute/thinkbox-stoke.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *computeContainer) ElasticContainerServiceRounded(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/compute/elastic-container-service-rounded.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *computeContainer) ElasticContainerService(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/compute/elastic-container-service.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *computeContainer) Lightsail(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/compute/lightsail.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *computeContainer) ThinkboxDraft(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/compute/thinkbox-draft.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *computeContainer) ThinkboxFrost(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/compute/thinkbox-frost.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *computeContainer) VmwareCloudOnAws(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/compute/vmware-cloud-on-aws.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *computeContainer) ComputeRounded(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/compute/compute-rounded.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *computeContainer) Ec2Rounded(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/compute/ec2-rounded.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *computeContainer) ServerlessApplicationRepository(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/compute/serverless-application-repository.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *computeContainer) ElasticKubernetesService(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/compute/elastic-kubernetes-service.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *computeContainer) ThinkboxKrakatoaRounded(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/compute/thinkbox-krakatoa-rounded.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }
 
@@ -182,28 +22,18 @@ func (c *computeContainer) ApplicationAutoScaling(opts ...diagram.NodeOption) *d
 	return diagram.NewNode(nopts...)
 }
 
+func (c *computeContainer) BatchRounded(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/compute/batch-rounded.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
 func (c *computeContainer) Batch(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/compute/batch.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }
 
-func (c *computeContainer) Ec2(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/compute/ec2.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *computeContainer) ThinkboxFrostRounded(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/compute/thinkbox-frost-rounded.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *computeContainer) ThinkboxKrakatoa(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/compute/thinkbox-krakatoa.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *computeContainer) ThinkboxXmesh(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/compute/thinkbox-xmesh.png")}, c.opts, opts)
+func (c *computeContainer) ComputeRounded(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/compute/compute-rounded.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }
 
@@ -217,7 +47,177 @@ func (c *computeContainer) Ec2ContainerRegistryRounded(opts ...diagram.NodeOptio
 	return diagram.NewNode(nopts...)
 }
 
+func (c *computeContainer) Ec2ContainerRegistry(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/compute/ec2-container-registry.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *computeContainer) Ec2Rounded(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/compute/ec2-rounded.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *computeContainer) Ec2(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/compute/ec2.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *computeContainer) ElasticBeanstalkRounded(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/compute/elastic-beanstalk-rounded.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *computeContainer) ElasticBeanstalk(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/compute/elastic-beanstalk.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *computeContainer) ElasticContainerServiceRounded(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/compute/elastic-container-service-rounded.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *computeContainer) ElasticContainerService(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/compute/elastic-container-service.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *computeContainer) ElasticKubernetesServiceRounded(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/compute/elastic-kubernetes-service-rounded.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *computeContainer) ElasticKubernetesService(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/compute/elastic-kubernetes-service.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *computeContainer) FargateRounded(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/compute/fargate-rounded.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *computeContainer) Fargate(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/compute/fargate.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *computeContainer) LambdaRounded(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/compute/lambda-rounded.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *computeContainer) Lambda(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/compute/lambda.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
 func (c *computeContainer) LightsailRounded(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/compute/lightsail-rounded.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *computeContainer) Lightsail(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/compute/lightsail.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *computeContainer) OutpostsRounded(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/compute/outposts-rounded.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *computeContainer) Outposts(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/compute/outposts.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *computeContainer) ServerlessApplicationRepositoryRounded(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/compute/serverless-application-repository-rounded.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *computeContainer) ServerlessApplicationRepository(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/compute/serverless-application-repository.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *computeContainer) ThinkboxDeadlineRounded(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/compute/thinkbox-deadline-rounded.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *computeContainer) ThinkboxDeadline(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/compute/thinkbox-deadline.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *computeContainer) ThinkboxDraftRounded(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/compute/thinkbox-draft-rounded.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *computeContainer) ThinkboxDraft(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/compute/thinkbox-draft.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *computeContainer) ThinkboxFrostRounded(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/compute/thinkbox-frost-rounded.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *computeContainer) ThinkboxFrost(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/compute/thinkbox-frost.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *computeContainer) ThinkboxKrakatoaRounded(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/compute/thinkbox-krakatoa-rounded.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *computeContainer) ThinkboxKrakatoa(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/compute/thinkbox-krakatoa.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *computeContainer) ThinkboxSequoiaRounded(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/compute/thinkbox-sequoia-rounded.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *computeContainer) ThinkboxSequoia(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/compute/thinkbox-sequoia.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *computeContainer) ThinkboxStokeRounded(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/compute/thinkbox-stoke-rounded.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *computeContainer) ThinkboxStoke(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/compute/thinkbox-stoke.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *computeContainer) ThinkboxXmeshRounded(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/compute/thinkbox-xmesh-rounded.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *computeContainer) ThinkboxXmesh(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/compute/thinkbox-xmesh.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *computeContainer) VmwareCloudOnAwsRounded(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/compute/vmware-cloud-on-aws-rounded.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *computeContainer) VmwareCloudOnAws(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/compute/vmware-cloud-on-aws.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }

--- a/nodes/aws/cost.go
+++ b/nodes/aws/cost.go
@@ -12,6 +12,11 @@ var Cost = &costContainer{
 	path: "assets/aws/cost",
 }
 
+func (c *costContainer) Budgets(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/cost/budgets.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
 func (c *costContainer) CostAndUsageReport(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/cost/cost-and-usage-report.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
@@ -29,10 +34,5 @@ func (c *costContainer) ReservedInstanceReporting(opts ...diagram.NodeOption) *d
 
 func (c *costContainer) SavingsPlans(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/cost/savings-plans.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *costContainer) Budgets(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/cost/budgets.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }

--- a/nodes/aws/database.go
+++ b/nodes/aws/database.go
@@ -12,16 +12,6 @@ var Database = &databaseContainer{
 	path: "assets/aws/database",
 }
 
-func (c *databaseContainer) Dynamodb(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/database/dynamodb.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *databaseContainer) Neptune(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/database/neptune.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
 func (c *databaseContainer) Aurora(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/database/aurora.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
@@ -42,33 +32,8 @@ func (c *databaseContainer) DocumentdbMongodbCompatibility(opts ...diagram.NodeO
 	return diagram.NewNode(nopts...)
 }
 
-func (c *databaseContainer) Elasticache(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/database/elasticache.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *databaseContainer) RdsOnVmware(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/database/rds-on-vmware.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *databaseContainer) Timestream(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/database/timestream.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
 func (c *databaseContainer) DynamodbDax(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/database/dynamodb-dax.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *databaseContainer) QuantumLedgerDatabaseQldb(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/database/quantum-ledger-database-qldb.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *databaseContainer) Redshift(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/database/redshift.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }
 
@@ -82,7 +47,42 @@ func (c *databaseContainer) DynamodbTable(opts ...diagram.NodeOption) *diagram.N
 	return diagram.NewNode(nopts...)
 }
 
+func (c *databaseContainer) Dynamodb(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/database/dynamodb.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *databaseContainer) Elasticache(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/database/elasticache.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *databaseContainer) Neptune(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/database/neptune.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *databaseContainer) QuantumLedgerDatabaseQldb(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/database/quantum-ledger-database-qldb.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *databaseContainer) RdsOnVmware(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/database/rds-on-vmware.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
 func (c *databaseContainer) Rds(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/database/rds.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *databaseContainer) Redshift(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/database/redshift.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *databaseContainer) Timestream(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/database/timestream.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }

--- a/nodes/aws/devtools.go
+++ b/nodes/aws/devtools.go
@@ -12,16 +12,6 @@ var Devtools = &devtoolsContainer{
 	path: "assets/aws/devtools",
 }
 
-func (c *devtoolsContainer) ToolsAndSdks(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/devtools/tools-and-sdks.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *devtoolsContainer) XRay(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/devtools/x-ray.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
 func (c *devtoolsContainer) CloudDevelopmentKit(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/devtools/cloud-development-kit.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
@@ -42,13 +32,13 @@ func (c *devtoolsContainer) Codecommit(opts ...diagram.NodeOption) *diagram.Node
 	return diagram.NewNode(nopts...)
 }
 
-func (c *devtoolsContainer) Codepipeline(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/devtools/codepipeline.png")}, c.opts, opts)
+func (c *devtoolsContainer) Codedeploy(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/devtools/codedeploy.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }
 
-func (c *devtoolsContainer) Codedeploy(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/devtools/codedeploy.png")}, c.opts, opts)
+func (c *devtoolsContainer) Codepipeline(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/devtools/codepipeline.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }
 
@@ -64,5 +54,15 @@ func (c *devtoolsContainer) CommandLineInterface(opts ...diagram.NodeOption) *di
 
 func (c *devtoolsContainer) DeveloperTools(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/devtools/developer-tools.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *devtoolsContainer) ToolsAndSdks(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/devtools/tools-and-sdks.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *devtoolsContainer) XRay(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/devtools/x-ray.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }

--- a/nodes/aws/enablement.go
+++ b/nodes/aws/enablement.go
@@ -12,16 +12,6 @@ var Enablement = &enablementContainer{
 	path: "assets/aws/enablement",
 }
 
-func (c *enablementContainer) ProfessionalServices(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/enablement/professional-services.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *enablementContainer) Support(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/enablement/support.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
 func (c *enablementContainer) Iq(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/enablement/iq.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
@@ -29,5 +19,15 @@ func (c *enablementContainer) Iq(opts ...diagram.NodeOption) *diagram.Node {
 
 func (c *enablementContainer) ManagedServices(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/enablement/managed-services.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *enablementContainer) ProfessionalServices(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/enablement/professional-services.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *enablementContainer) Support(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/enablement/support.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }

--- a/nodes/aws/general.go
+++ b/nodes/aws/general.go
@@ -22,16 +22,6 @@ func (c *generalContainer) General(opts ...diagram.NodeOption) *diagram.Node {
 	return diagram.NewNode(nopts...)
 }
 
-func (c *generalContainer) GenericOfficeBuilding(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/general/generic-office-building.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *generalContainer) User(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/general/user.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
 func (c *generalContainer) GenericDatabase(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/general/generic-database.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
@@ -39,6 +29,11 @@ func (c *generalContainer) GenericDatabase(opts ...diagram.NodeOption) *diagram.
 
 func (c *generalContainer) GenericFirewall(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/general/generic-firewall.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *generalContainer) GenericOfficeBuilding(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/general/generic-office-building.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }
 
@@ -59,6 +54,11 @@ func (c *generalContainer) Marketplace(opts ...diagram.NodeOption) *diagram.Node
 
 func (c *generalContainer) TradicionalServer(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/general/tradicional-server.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *generalContainer) User(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/general/user.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }
 

--- a/nodes/aws/integration.go
+++ b/nodes/aws/integration.go
@@ -12,6 +12,11 @@ var Integration = &integrationContainer{
 	path: "assets/aws/integration",
 }
 
+func (c *integrationContainer) ApplicationIntegration(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/integration/application-integration.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
 func (c *integrationContainer) Appsync(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/integration/appsync.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
@@ -44,10 +49,5 @@ func (c *integrationContainer) SimpleQueueServiceSqs(opts ...diagram.NodeOption)
 
 func (c *integrationContainer) StepFunctions(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/integration/step-functions.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *integrationContainer) ApplicationIntegration(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/integration/application-integration.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }

--- a/nodes/aws/iot.go
+++ b/nodes/aws/iot.go
@@ -17,113 +17,8 @@ func (c *iotContainer) Freertos(opts ...diagram.NodeOption) *diagram.Node {
 	return diagram.NewNode(nopts...)
 }
 
-func (c *iotContainer) IotLambda(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/iot/iot-lambda.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *iotContainer) IotTopic(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/iot/iot-topic.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *iotContainer) IotShadow(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/iot/iot-shadow.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *iotContainer) IotAction(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/iot/iot-action.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *iotContainer) IotAlexaSkill(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/iot/iot-alexa-skill.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *iotContainer) IotEvents(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/iot/iot-events.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *iotContainer) IotHardwareBoard(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/iot/iot-hardware-board.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *iotContainer) IotJobs(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/iot/iot-jobs.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *iotContainer) IotPolicy(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/iot/iot-policy.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *iotContainer) IotPolicyEmergency(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/iot/iot-policy-emergency.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *iotContainer) IotSitewise(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/iot/iot-sitewise.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
 func (c *iotContainer) InternetOfThings(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/iot/internet-of-things.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *iotContainer) IotAlexaEcho(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/iot/iot-alexa-echo.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *iotContainer) IotCore(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/iot/iot-core.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *iotContainer) IotDeviceManagement(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/iot/iot-device-management.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *iotContainer) IotGreengrassConnector(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/iot/iot-greengrass-connector.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *iotContainer) IotHttp(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/iot/iot-http.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *iotContainer) IotAnalytics(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/iot/iot-analytics.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *iotContainer) IotCamera(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/iot/iot-camera.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *iotContainer) IotHttp2(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/iot/iot-http2.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *iotContainer) IotThingsGraph(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/iot/iot-things-graph.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *iotContainer) IotDeviceDefender(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/iot/iot-device-defender.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }
 
@@ -132,8 +27,33 @@ func (c *iotContainer) Iot1Click(opts ...diagram.NodeOption) *diagram.Node {
 	return diagram.NewNode(nopts...)
 }
 
+func (c *iotContainer) IotAction(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/iot/iot-action.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *iotContainer) IotAlexaEcho(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/iot/iot-alexa-echo.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *iotContainer) IotAlexaSkill(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/iot/iot-alexa-skill.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *iotContainer) IotAnalytics(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/iot/iot-analytics.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
 func (c *iotContainer) IotButton(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/iot/iot-button.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *iotContainer) IotCamera(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/iot/iot-camera.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }
 
@@ -142,8 +62,58 @@ func (c *iotContainer) IotCertificate(opts ...diagram.NodeOption) *diagram.Node 
 	return diagram.NewNode(nopts...)
 }
 
+func (c *iotContainer) IotCore(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/iot/iot-core.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *iotContainer) IotDeviceDefender(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/iot/iot-device-defender.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *iotContainer) IotDeviceManagement(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/iot/iot-device-management.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *iotContainer) IotEvents(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/iot/iot-events.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *iotContainer) IotGreengrassConnector(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/iot/iot-greengrass-connector.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
 func (c *iotContainer) IotGreengrass(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/iot/iot-greengrass.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *iotContainer) IotHardwareBoard(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/iot/iot-hardware-board.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *iotContainer) IotHttp(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/iot/iot-http.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *iotContainer) IotHttp2(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/iot/iot-http2.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *iotContainer) IotJobs(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/iot/iot-jobs.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *iotContainer) IotLambda(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/iot/iot-lambda.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }
 
@@ -152,7 +122,37 @@ func (c *iotContainer) IotMqtt(opts ...diagram.NodeOption) *diagram.Node {
 	return diagram.NewNode(nopts...)
 }
 
+func (c *iotContainer) IotPolicyEmergency(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/iot/iot-policy-emergency.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *iotContainer) IotPolicy(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/iot/iot-policy.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
 func (c *iotContainer) IotRule(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/iot/iot-rule.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *iotContainer) IotShadow(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/iot/iot-shadow.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *iotContainer) IotSitewise(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/iot/iot-sitewise.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *iotContainer) IotThingsGraph(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/iot/iot-things-graph.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *iotContainer) IotTopic(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/iot/iot-topic.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }

--- a/nodes/aws/management.go
+++ b/nodes/aws/management.go
@@ -12,23 +12,8 @@ var Management = &managementContainer{
 	path: "assets/aws/management",
 }
 
-func (c *managementContainer) Config(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/management/config.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *managementContainer) ManagementConsole(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/management/management-console.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *managementContainer) SystemsManager(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/management/systems-manager.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *managementContainer) WellArchitectedTool(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/management/well-architected-tool.png")}, c.opts, opts)
+func (c *managementContainer) AutoScaling(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/management/auto-scaling.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }
 
@@ -37,48 +22,8 @@ func (c *managementContainer) Cloudformation(opts ...diagram.NodeOption) *diagra
 	return diagram.NewNode(nopts...)
 }
 
-func (c *managementContainer) LicenseManager(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/management/license-manager.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *managementContainer) ManagedServices(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/management/managed-services.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *managementContainer) ServiceCatalog(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/management/service-catalog.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *managementContainer) TrustedAdvisor(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/management/trusted-advisor.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
 func (c *managementContainer) Cloudtrail(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/management/cloudtrail.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *managementContainer) ControlTower(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/management/control-tower.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *managementContainer) Organizations(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/management/organizations.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *managementContainer) SystemsManagerParameterStore(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/management/systems-manager-parameter-store.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *managementContainer) AutoScaling(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/management/auto-scaling.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }
 
@@ -97,7 +42,62 @@ func (c *managementContainer) CommandLineInterface(opts ...diagram.NodeOption) *
 	return diagram.NewNode(nopts...)
 }
 
+func (c *managementContainer) Config(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/management/config.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *managementContainer) ControlTower(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/management/control-tower.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *managementContainer) LicenseManager(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/management/license-manager.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *managementContainer) ManagedServices(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/management/managed-services.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *managementContainer) ManagementConsole(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/management/management-console.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
 func (c *managementContainer) Opsworks(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/management/opsworks.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *managementContainer) Organizations(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/management/organizations.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *managementContainer) ServiceCatalog(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/management/service-catalog.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *managementContainer) SystemsManagerParameterStore(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/management/systems-manager-parameter-store.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *managementContainer) SystemsManager(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/management/systems-manager.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *managementContainer) TrustedAdvisor(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/management/trusted-advisor.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *managementContainer) WellArchitectedTool(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/management/well-architected-tool.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }

--- a/nodes/aws/media.go
+++ b/nodes/aws/media.go
@@ -22,21 +22,6 @@ func (c *mediaContainer) ElementalConductor(opts ...diagram.NodeOption) *diagram
 	return diagram.NewNode(nopts...)
 }
 
-func (c *mediaContainer) ElementalMedialive(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/media/elemental-medialive.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *mediaContainer) ElementalMediapackage(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/media/elemental-mediapackage.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *mediaContainer) ElementalServer(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/media/elemental-server.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
 func (c *mediaContainer) ElementalDelta(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/media/elemental-delta.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
@@ -57,6 +42,16 @@ func (c *mediaContainer) ElementalMediaconvert(opts ...diagram.NodeOption) *diag
 	return diagram.NewNode(nopts...)
 }
 
+func (c *mediaContainer) ElementalMedialive(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/media/elemental-medialive.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *mediaContainer) ElementalMediapackage(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/media/elemental-mediapackage.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
 func (c *mediaContainer) ElementalMediastore(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/media/elemental-mediastore.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
@@ -64,5 +59,10 @@ func (c *mediaContainer) ElementalMediastore(opts ...diagram.NodeOption) *diagra
 
 func (c *mediaContainer) ElementalMediatailor(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/media/elemental-mediatailor.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *mediaContainer) ElementalServer(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/media/elemental-server.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }

--- a/nodes/aws/migration.go
+++ b/nodes/aws/migration.go
@@ -12,8 +12,18 @@ var Migration = &migrationContainer{
 	path: "assets/aws/migration",
 }
 
-func (c *migrationContainer) TransferForSftp(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/migration/transfer-for-sftp.png")}, c.opts, opts)
+func (c *migrationContainer) ApplicationDiscoveryService(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/migration/application-discovery-service.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *migrationContainer) CloudendureMigration(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/migration/cloudendure-migration.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *migrationContainer) DatabaseMigrationService(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/migration/database-migration-service.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }
 
@@ -24,11 +34,6 @@ func (c *migrationContainer) Datasync(opts ...diagram.NodeOption) *diagram.Node 
 
 func (c *migrationContainer) MigrationAndTransfer(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/migration/migration-and-transfer.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *migrationContainer) Snowball(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/migration/snowball.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }
 
@@ -47,22 +52,17 @@ func (c *migrationContainer) SnowballEdge(opts ...diagram.NodeOption) *diagram.N
 	return diagram.NewNode(nopts...)
 }
 
+func (c *migrationContainer) Snowball(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/migration/snowball.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
 func (c *migrationContainer) Snowmobile(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/migration/snowmobile.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }
 
-func (c *migrationContainer) ApplicationDiscoveryService(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/migration/application-discovery-service.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *migrationContainer) CloudendureMigration(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/migration/cloudendure-migration.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *migrationContainer) DatabaseMigrationService(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/migration/database-migration-service.png")}, c.opts, opts)
+func (c *migrationContainer) TransferForSftp(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/migration/transfer-for-sftp.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }

--- a/nodes/aws/ml.go
+++ b/nodes/aws/ml.go
@@ -12,63 +12,8 @@ var Ml = &mlContainer{
 	path: "assets/aws/ml",
 }
 
-func (c *mlContainer) SagemakerTrainingJob(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/ml/sagemaker-training-job.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *mlContainer) Deepracer(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/ml/deepracer.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *mlContainer) SagemakerNotebook(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/ml/sagemaker-notebook.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *mlContainer) ElasticInference(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/ml/elastic-inference.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *mlContainer) Polly(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/ml/polly.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *mlContainer) SagemakerModel(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/ml/sagemaker-model.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *mlContainer) Transcribe(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/ml/transcribe.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
 func (c *mlContainer) ApacheMxnetOnAws(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/ml/apache-mxnet-on-aws.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *mlContainer) DeepLearningAmis(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/ml/deep-learning-amis.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *mlContainer) Sagemaker(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/ml/sagemaker.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *mlContainer) TensorflowOnAws(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/ml/tensorflow-on-aws.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *mlContainer) Translate(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/ml/translate.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }
 
@@ -77,8 +22,28 @@ func (c *mlContainer) Comprehend(opts ...diagram.NodeOption) *diagram.Node {
 	return diagram.NewNode(nopts...)
 }
 
-func (c *mlContainer) MachineLearning(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/ml/machine-learning.png")}, c.opts, opts)
+func (c *mlContainer) DeepLearningAmis(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/ml/deep-learning-amis.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *mlContainer) DeepLearningContainers(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/ml/deep-learning-containers.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *mlContainer) Deeplens(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/ml/deeplens.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *mlContainer) Deepracer(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/ml/deepracer.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *mlContainer) ElasticInference(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/ml/elastic-inference.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }
 
@@ -92,8 +57,18 @@ func (c *mlContainer) Lex(opts ...diagram.NodeOption) *diagram.Node {
 	return diagram.NewNode(nopts...)
 }
 
+func (c *mlContainer) MachineLearning(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/ml/machine-learning.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
 func (c *mlContainer) Personalize(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/ml/personalize.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *mlContainer) Polly(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/ml/polly.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }
 
@@ -107,17 +82,42 @@ func (c *mlContainer) SagemakerGroundTruth(opts ...diagram.NodeOption) *diagram.
 	return diagram.NewNode(nopts...)
 }
 
+func (c *mlContainer) SagemakerModel(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/ml/sagemaker-model.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *mlContainer) SagemakerNotebook(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/ml/sagemaker-notebook.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *mlContainer) SagemakerTrainingJob(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/ml/sagemaker-training-job.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *mlContainer) Sagemaker(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/ml/sagemaker.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *mlContainer) TensorflowOnAws(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/ml/tensorflow-on-aws.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
 func (c *mlContainer) Textract(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/ml/textract.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }
 
-func (c *mlContainer) DeepLearningContainers(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/ml/deep-learning-containers.png")}, c.opts, opts)
+func (c *mlContainer) Transcribe(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/ml/transcribe.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }
 
-func (c *mlContainer) Deeplens(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/ml/deeplens.png")}, c.opts, opts)
+func (c *mlContainer) Translate(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/ml/translate.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }

--- a/nodes/aws/network.go
+++ b/nodes/aws/network.go
@@ -12,58 +12,18 @@ var Network = &networkContainer{
 	path: "assets/aws/network",
 }
 
-func (c *networkContainer) PrivateSubnet(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/network/private-subnet.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *networkContainer) PublicSubnet(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/network/public-subnet.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *networkContainer) SiteToSiteVpn(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/network/site-to-site-vpn.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
 func (c *networkContainer) ApiGateway(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/network/api-gateway.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }
 
-func (c *networkContainer) NetworkingAndContentDelivery(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/network/networking-and-content-delivery.png")}, c.opts, opts)
+func (c *networkContainer) AppMesh(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/network/app-mesh.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }
 
-func (c *networkContainer) Cloudfront(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/network/cloudfront.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *networkContainer) InternetGateway(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/network/internet-gateway.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *networkContainer) GlobalAccelerator(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/network/global-accelerator.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *networkContainer) NatGateway(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/network/nat-gateway.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *networkContainer) RouteTable(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/network/route-table.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *networkContainer) TransitGateway(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/network/transit-gateway.png")}, c.opts, opts)
+func (c *networkContainer) ClientVpn(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/network/client-vpn.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }
 
@@ -72,8 +32,8 @@ func (c *networkContainer) CloudMap(opts ...diagram.NodeOption) *diagram.Node {
 	return diagram.NewNode(nopts...)
 }
 
-func (c *networkContainer) Endpoint(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/network/endpoint.png")}, c.opts, opts)
+func (c *networkContainer) Cloudfront(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/network/cloudfront.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }
 
@@ -87,8 +47,38 @@ func (c *networkContainer) ElasticLoadBalancing(opts ...diagram.NodeOption) *dia
 	return diagram.NewNode(nopts...)
 }
 
+func (c *networkContainer) Endpoint(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/network/endpoint.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *networkContainer) GlobalAccelerator(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/network/global-accelerator.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *networkContainer) InternetGateway(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/network/internet-gateway.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
 func (c *networkContainer) Nacl(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/network/nacl.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *networkContainer) NatGateway(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/network/nat-gateway.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *networkContainer) NetworkingAndContentDelivery(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/network/networking-and-content-delivery.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *networkContainer) PrivateSubnet(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/network/private-subnet.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }
 
@@ -97,23 +87,33 @@ func (c *networkContainer) Privatelink(opts ...diagram.NodeOption) *diagram.Node
 	return diagram.NewNode(nopts...)
 }
 
+func (c *networkContainer) PublicSubnet(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/network/public-subnet.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
 func (c *networkContainer) Route53(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/network/route-53.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }
 
+func (c *networkContainer) RouteTable(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/network/route-table.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *networkContainer) SiteToSiteVpn(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/network/site-to-site-vpn.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *networkContainer) TransitGateway(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/network/transit-gateway.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
 func (c *networkContainer) VpcPeering(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/network/vpc-peering.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *networkContainer) AppMesh(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/network/app-mesh.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *networkContainer) ClientVpn(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/network/client-vpn.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }
 

--- a/nodes/aws/security.go
+++ b/nodes/aws/security.go
@@ -12,53 +12,8 @@ var Security = &securityContainer{
 	path: "assets/aws/security",
 }
 
-func (c *securityContainer) KeyManagementService(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/security/key-management-service.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *securityContainer) SingleSignOn(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/security/single-sign-on.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *securityContainer) CloudDirectory(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/security/cloud-directory.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *securityContainer) Guardduty(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/security/guardduty.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *securityContainer) IdentityAndAccessManagementIamAwsSts(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/security/identity-and-access-management-iam-aws-sts.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *securityContainer) IdentityAndAccessManagementIam(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/security/identity-and-access-management-iam.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *securityContainer) SecretsManager(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/security/secrets-manager.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *securityContainer) SecurityIdentityAndCompliance(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/security/security-identity-and-compliance.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *securityContainer) Shield(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/security/shield.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *securityContainer) Cloudhsm(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/security/cloudhsm.png")}, c.opts, opts)
+func (c *securityContainer) Artifact(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/security/artifact.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }
 
@@ -67,8 +22,23 @@ func (c *securityContainer) CertificateManager(opts ...diagram.NodeOption) *diag
 	return diagram.NewNode(nopts...)
 }
 
+func (c *securityContainer) CloudDirectory(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/security/cloud-directory.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *securityContainer) Cloudhsm(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/security/cloudhsm.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
 func (c *securityContainer) Cognito(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/security/cognito.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *securityContainer) Detective(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/security/detective.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }
 
@@ -77,8 +47,23 @@ func (c *securityContainer) DirectoryService(opts ...diagram.NodeOption) *diagra
 	return diagram.NewNode(nopts...)
 }
 
+func (c *securityContainer) FirewallManager(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/security/firewall-manager.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *securityContainer) Guardduty(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/security/guardduty.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
 func (c *securityContainer) IdentityAndAccessManagementIamAccessAnalyzer(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/security/identity-and-access-management-iam-access-analyzer.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *securityContainer) IdentityAndAccessManagementIamAwsSts(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/security/identity-and-access-management-iam-aws-sts.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }
 
@@ -92,18 +77,8 @@ func (c *securityContainer) IdentityAndAccessManagementIamRole(opts ...diagram.N
 	return diagram.NewNode(nopts...)
 }
 
-func (c *securityContainer) ResourceAccessManager(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/security/resource-access-manager.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *securityContainer) Artifact(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/security/artifact.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *securityContainer) FirewallManager(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/security/firewall-manager.png")}, c.opts, opts)
+func (c *securityContainer) IdentityAndAccessManagementIam(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/security/identity-and-access-management-iam.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }
 
@@ -112,8 +87,23 @@ func (c *securityContainer) Inspector(opts ...diagram.NodeOption) *diagram.Node 
 	return diagram.NewNode(nopts...)
 }
 
+func (c *securityContainer) KeyManagementService(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/security/key-management-service.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
 func (c *securityContainer) Macie(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/security/macie.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *securityContainer) ResourceAccessManager(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/security/resource-access-manager.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *securityContainer) SecretsManager(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/security/secrets-manager.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }
 
@@ -122,12 +112,22 @@ func (c *securityContainer) SecurityHub(opts ...diagram.NodeOption) *diagram.Nod
 	return diagram.NewNode(nopts...)
 }
 
-func (c *securityContainer) Waf(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/security/waf.png")}, c.opts, opts)
+func (c *securityContainer) SecurityIdentityAndCompliance(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/security/security-identity-and-compliance.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }
 
-func (c *securityContainer) Detective(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/security/detective.png")}, c.opts, opts)
+func (c *securityContainer) Shield(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/security/shield.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *securityContainer) SingleSignOn(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/security/single-sign-on.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *securityContainer) Waf(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/security/waf.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }

--- a/nodes/aws/storage.go
+++ b/nodes/aws/storage.go
@@ -12,58 +12,18 @@ var Storage = &storageContainer{
 	path: "assets/aws/storage",
 }
 
-func (c *storageContainer) CloudendureDisasterRecovery(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/storage/cloudendure-disaster-recovery.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *storageContainer) FsxForLustre(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/storage/fsx-for-lustre.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *storageContainer) Fsx(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/storage/fsx.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
 func (c *storageContainer) Backup(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/storage/backup.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }
 
-func (c *storageContainer) SimpleStorageServiceS3(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/storage/simple-storage-service-s3.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *storageContainer) Snowmobile(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/storage/snowmobile.png")}, c.opts, opts)
+func (c *storageContainer) CloudendureDisasterRecovery(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/storage/cloudendure-disaster-recovery.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }
 
 func (c *storageContainer) EfsInfrequentaccessPrimaryBg(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/storage/efs-infrequentaccess-primary-bg.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *storageContainer) FsxForWindowsFileServer(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/storage/fsx-for-windows-file-server.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *storageContainer) SnowballEdge(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/storage/snowball-edge.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *storageContainer) StorageGateway(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/storage/storage-gateway.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *storageContainer) Storage(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/storage/storage.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }
 
@@ -82,12 +42,52 @@ func (c *storageContainer) ElasticFileSystemEfs(opts ...diagram.NodeOption) *dia
 	return diagram.NewNode(nopts...)
 }
 
+func (c *storageContainer) FsxForLustre(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/storage/fsx-for-lustre.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *storageContainer) FsxForWindowsFileServer(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/storage/fsx-for-windows-file-server.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *storageContainer) Fsx(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/storage/fsx.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
 func (c *storageContainer) S3Glacier(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/storage/s3-glacier.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }
 
+func (c *storageContainer) SimpleStorageServiceS3(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/storage/simple-storage-service-s3.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *storageContainer) SnowballEdge(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/storage/snowball-edge.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
 func (c *storageContainer) Snowball(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/storage/snowball.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *storageContainer) Snowmobile(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/storage/snowmobile.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *storageContainer) StorageGateway(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/storage/storage-gateway.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *storageContainer) Storage(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/aws/storage/storage.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }

--- a/nodes/azure/analytics.go
+++ b/nodes/azure/analytics.go
@@ -17,26 +17,6 @@ func (c *analyticsContainer) AnalysisServices(opts ...diagram.NodeOption) *diagr
 	return diagram.NewNode(nopts...)
 }
 
-func (c *analyticsContainer) DataLakeAnalytics(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/analytics/data-lake-analytics.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *analyticsContainer) Hdinsightclusters(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/analytics/hdinsightclusters.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *analyticsContainer) LogAnalyticsWorkspaces(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/analytics/log-analytics-workspaces.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *analyticsContainer) StreamAnalyticsJobs(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/analytics/stream-analytics-jobs.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
 func (c *analyticsContainer) DataExplorerClusters(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/analytics/data-explorer-clusters.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
@@ -44,6 +24,11 @@ func (c *analyticsContainer) DataExplorerClusters(opts ...diagram.NodeOption) *d
 
 func (c *analyticsContainer) DataFactories(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/analytics/data-factories.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *analyticsContainer) DataLakeAnalytics(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/analytics/data-lake-analytics.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }
 
@@ -64,5 +49,20 @@ func (c *analyticsContainer) EventHubClusters(opts ...diagram.NodeOption) *diagr
 
 func (c *analyticsContainer) EventHubs(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/analytics/event-hubs.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *analyticsContainer) Hdinsightclusters(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/analytics/hdinsightclusters.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *analyticsContainer) LogAnalyticsWorkspaces(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/analytics/log-analytics-workspaces.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *analyticsContainer) StreamAnalyticsJobs(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/analytics/stream-analytics-jobs.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }

--- a/nodes/azure/compute.go
+++ b/nodes/azure/compute.go
@@ -12,16 +12,6 @@ var Compute = &computeContainer{
 	path: "assets/azure/compute",
 }
 
-func (c *computeContainer) SapHanaOnAzure(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/compute/sap-hana-on-azure.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *computeContainer) VmLinux(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/compute/vm-linux.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
 func (c *computeContainer) AvailabilitySets(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/compute/availability-sets.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
@@ -32,8 +22,23 @@ func (c *computeContainer) BatchAccounts(opts ...diagram.NodeOption) *diagram.No
 	return diagram.NewNode(nopts...)
 }
 
+func (c *computeContainer) CitrixVirtualDesktopsEssentials(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/compute/citrix-virtual-desktops-essentials.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
 func (c *computeContainer) CloudServicesClassic(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/compute/cloud-services-classic.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *computeContainer) CloudServices(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/compute/cloud-services.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *computeContainer) CloudsimpleVirtualMachines(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/compute/cloudsimple-virtual-machines.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }
 
@@ -52,6 +57,11 @@ func (c *computeContainer) DiskSnapshots(opts ...diagram.NodeOption) *diagram.No
 	return diagram.NewNode(nopts...)
 }
 
+func (c *computeContainer) Disks(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/compute/disks.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
 func (c *computeContainer) FunctionApps(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/compute/function-apps.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
@@ -59,6 +69,16 @@ func (c *computeContainer) FunctionApps(opts ...diagram.NodeOption) *diagram.Nod
 
 func (c *computeContainer) KubernetesServices(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/compute/kubernetes-services.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *computeContainer) MeshApplications(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/compute/mesh-applications.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *computeContainer) SapHanaOnAzure(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/compute/sap-hana-on-azure.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }
 
@@ -77,37 +97,17 @@ func (c *computeContainer) VmImages(opts ...diagram.NodeOption) *diagram.Node {
 	return diagram.NewNode(nopts...)
 }
 
-func (c *computeContainer) Vm(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/compute/vm.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *computeContainer) CloudServices(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/compute/cloud-services.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *computeContainer) Disks(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/compute/disks.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *computeContainer) MeshApplications(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/compute/mesh-applications.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *computeContainer) CitrixVirtualDesktopsEssentials(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/compute/citrix-virtual-desktops-essentials.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *computeContainer) CloudsimpleVirtualMachines(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/compute/cloudsimple-virtual-machines.png")}, c.opts, opts)
+func (c *computeContainer) VmLinux(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/compute/vm-linux.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }
 
 func (c *computeContainer) VmWindows(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/compute/vm-windows.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *computeContainer) Vm(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/compute/vm.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }

--- a/nodes/azure/database.go
+++ b/nodes/azure/database.go
@@ -17,8 +17,18 @@ func (c *databaseContainer) BlobStorage(opts ...diagram.NodeOption) *diagram.Nod
 	return diagram.NewNode(nopts...)
 }
 
+func (c *databaseContainer) CacheForRedis(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/database/cache-for-redis.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
 func (c *databaseContainer) CosmosDb(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/database/cosmos-db.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *databaseContainer) DataLake(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/database/data-lake.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }
 
@@ -27,18 +37,13 @@ func (c *databaseContainer) DatabaseForMariadbServers(opts ...diagram.NodeOption
 	return diagram.NewNode(nopts...)
 }
 
+func (c *databaseContainer) DatabaseForMysqlServers(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/database/database-for-mysql-servers.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
 func (c *databaseContainer) DatabaseForPostgresqlServers(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/database/database-for-postgresql-servers.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *databaseContainer) SqlServers(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/database/sql-servers.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *databaseContainer) DataLake(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/database/data-lake.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }
 
@@ -62,26 +67,6 @@ func (c *databaseContainer) SqlDatabases(opts ...diagram.NodeOption) *diagram.No
 	return diagram.NewNode(nopts...)
 }
 
-func (c *databaseContainer) VirtualClusters(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/database/virtual-clusters.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *databaseContainer) VirtualDatacenter(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/database/virtual-datacenter.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *databaseContainer) CacheForRedis(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/database/cache-for-redis.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *databaseContainer) DatabaseForMysqlServers(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/database/database-for-mysql-servers.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
 func (c *databaseContainer) SqlDatawarehouse(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/database/sql-datawarehouse.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
@@ -94,5 +79,20 @@ func (c *databaseContainer) SqlManagedInstances(opts ...diagram.NodeOption) *dia
 
 func (c *databaseContainer) SqlServerStretchDatabases(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/database/sql-server-stretch-databases.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *databaseContainer) SqlServers(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/database/sql-servers.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *databaseContainer) VirtualClusters(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/database/virtual-clusters.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *databaseContainer) VirtualDatacenter(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/database/virtual-datacenter.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }

--- a/nodes/azure/devops.go
+++ b/nodes/azure/devops.go
@@ -12,6 +12,21 @@ var Devops = &devopsContainer{
 	path: "assets/azure/devops",
 }
 
+func (c *devopsContainer) ApplicationInsights(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/devops/application-insights.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *devopsContainer) Artifacts(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/devops/artifacts.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *devopsContainer) Boards(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/devops/boards.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
 func (c *devopsContainer) Devops(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/devops/devops.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
@@ -34,20 +49,5 @@ func (c *devopsContainer) Repos(opts ...diagram.NodeOption) *diagram.Node {
 
 func (c *devopsContainer) TestPlans(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/devops/test-plans.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *devopsContainer) ApplicationInsights(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/devops/application-insights.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *devopsContainer) Artifacts(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/devops/artifacts.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *devopsContainer) Boards(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/devops/boards.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }

--- a/nodes/azure/general.go
+++ b/nodes/azure/general.go
@@ -12,13 +12,53 @@ var General = &generalContainer{
 	path: "assets/azure/general",
 }
 
-func (c *generalContainer) Userprivacy(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/general/userprivacy.png")}, c.opts, opts)
+func (c *generalContainer) Allresources(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/general/allresources.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }
 
-func (c *generalContainer) Allresources(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/general/allresources.png")}, c.opts, opts)
+func (c *generalContainer) Azurehome(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/general/azurehome.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *generalContainer) Developertools(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/general/developertools.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *generalContainer) Helpsupport(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/general/helpsupport.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *generalContainer) Information(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/general/information.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *generalContainer) Managementgroups(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/general/managementgroups.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *generalContainer) Marketplace(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/general/marketplace.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *generalContainer) Quickstartcenter(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/general/quickstartcenter.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *generalContainer) Recent(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/general/recent.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *generalContainer) Reservations(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/general/reservations.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }
 
@@ -27,38 +67,8 @@ func (c *generalContainer) Resource(opts ...diagram.NodeOption) *diagram.Node {
 	return diagram.NewNode(nopts...)
 }
 
-func (c *generalContainer) Tags(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/general/tags.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *generalContainer) Twousericon(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/general/twousericon.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *generalContainer) Userhealthicon(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/general/userhealthicon.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *generalContainer) Supportrequests(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/general/supportrequests.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *generalContainer) Templates(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/general/templates.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *generalContainer) Usericon(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/general/usericon.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *generalContainer) Managementgroups(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/general/managementgroups.png")}, c.opts, opts)
+func (c *generalContainer) Resourcegroups(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/general/resourcegroups.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }
 
@@ -82,62 +92,52 @@ func (c *generalContainer) Support(opts ...diagram.NodeOption) *diagram.Node {
 	return diagram.NewNode(nopts...)
 }
 
-func (c *generalContainer) Userresource(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/general/userresource.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *generalContainer) Recent(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/general/recent.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *generalContainer) Reservations(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/general/reservations.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *generalContainer) Whatsnew(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/general/whatsnew.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *generalContainer) Azurehome(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/general/azurehome.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *generalContainer) Helpsupport(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/general/helpsupport.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *generalContainer) Information(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/general/information.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *generalContainer) Marketplace(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/general/marketplace.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *generalContainer) Quickstartcenter(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/general/quickstartcenter.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *generalContainer) Developertools(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/general/developertools.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *generalContainer) Resourcegroups(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/general/resourcegroups.png")}, c.opts, opts)
+func (c *generalContainer) Supportrequests(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/general/supportrequests.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }
 
 func (c *generalContainer) Tag(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/general/tag.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *generalContainer) Tags(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/general/tags.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *generalContainer) Templates(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/general/templates.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *generalContainer) Twousericon(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/general/twousericon.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *generalContainer) Userhealthicon(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/general/userhealthicon.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *generalContainer) Usericon(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/general/usericon.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *generalContainer) Userprivacy(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/general/userprivacy.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *generalContainer) Userresource(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/general/userresource.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *generalContainer) Whatsnew(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/general/whatsnew.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }

--- a/nodes/azure/identity.go
+++ b/nodes/azure/identity.go
@@ -12,21 +12,6 @@ var Identity = &identityContainer{
 	path: "assets/azure/identity",
 }
 
-func (c *identityContainer) ConditionalAccess(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/identity/conditional-access.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *identityContainer) IdentityGovernance(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/identity/identity-governance.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *identityContainer) InformationProtection(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/identity/information-protection.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
 func (c *identityContainer) AccessReview(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/identity/access-review.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
@@ -34,26 +19,6 @@ func (c *identityContainer) AccessReview(opts ...diagram.NodeOption) *diagram.No
 
 func (c *identityContainer) ActiveDirectoryConnectHealth(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/identity/active-directory-connect-health.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *identityContainer) AdDomainServices(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/identity/ad-domain-services.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *identityContainer) AdPrivilegedIdentityManagement(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/identity/ad-privileged-identity-management.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *identityContainer) AppRegistrations(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/identity/app-registrations.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *identityContainer) ManagedIdentities(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/identity/managed-identities.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }
 
@@ -67,12 +32,47 @@ func (c *identityContainer) AdB2C(opts ...diagram.NodeOption) *diagram.Node {
 	return diagram.NewNode(nopts...)
 }
 
+func (c *identityContainer) AdDomainServices(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/identity/ad-domain-services.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
 func (c *identityContainer) AdIdentityProtection(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/identity/ad-identity-protection.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }
 
+func (c *identityContainer) AdPrivilegedIdentityManagement(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/identity/ad-privileged-identity-management.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *identityContainer) AppRegistrations(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/identity/app-registrations.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *identityContainer) ConditionalAccess(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/identity/conditional-access.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
 func (c *identityContainer) EnterpriseApplications(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/identity/enterprise-applications.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *identityContainer) IdentityGovernance(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/identity/identity-governance.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *identityContainer) InformationProtection(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/identity/information-protection.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *identityContainer) ManagedIdentities(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/identity/managed-identities.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }

--- a/nodes/azure/integration.go
+++ b/nodes/azure/integration.go
@@ -12,56 +12,6 @@ var Integration = &integrationContainer{
 	path: "assets/azure/integration",
 }
 
-func (c *integrationContainer) LogicApps(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/integration/logic-apps.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *integrationContainer) IntegrationServiceEnvironments(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/integration/integration-service-environments.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *integrationContainer) ServiceBusRelays(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/integration/service-bus-relays.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *integrationContainer) AppConfiguration(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/integration/app-configuration.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *integrationContainer) EventGridTopics(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/integration/event-grid-topics.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *integrationContainer) IntegrationAccounts(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/integration/integration-accounts.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *integrationContainer) SendgridAccounts(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/integration/sendgrid-accounts.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *integrationContainer) ServiceBus(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/integration/service-bus.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *integrationContainer) ServiceCatalogManagedApplicationDefinitions(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/integration/service-catalog-managed-application-definitions.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *integrationContainer) StorsimpleDeviceManagers(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/integration/storsimple-device-managers.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
 func (c *integrationContainer) ApiForFhir(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/integration/api-for-fhir.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
@@ -72,13 +22,13 @@ func (c *integrationContainer) ApiManagement(opts ...diagram.NodeOption) *diagra
 	return diagram.NewNode(nopts...)
 }
 
-func (c *integrationContainer) DataCatalog(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/integration/data-catalog.png")}, c.opts, opts)
+func (c *integrationContainer) AppConfiguration(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/integration/app-configuration.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }
 
-func (c *integrationContainer) SoftwareAsAService(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/integration/software-as-a-service.png")}, c.opts, opts)
+func (c *integrationContainer) DataCatalog(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/integration/data-catalog.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }
 
@@ -92,7 +42,57 @@ func (c *integrationContainer) EventGridSubscriptions(opts ...diagram.NodeOption
 	return diagram.NewNode(nopts...)
 }
 
+func (c *integrationContainer) EventGridTopics(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/integration/event-grid-topics.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *integrationContainer) IntegrationAccounts(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/integration/integration-accounts.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *integrationContainer) IntegrationServiceEnvironments(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/integration/integration-service-environments.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
 func (c *integrationContainer) LogicAppsCustomConnector(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/integration/logic-apps-custom-connector.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *integrationContainer) LogicApps(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/integration/logic-apps.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *integrationContainer) SendgridAccounts(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/integration/sendgrid-accounts.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *integrationContainer) ServiceBusRelays(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/integration/service-bus-relays.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *integrationContainer) ServiceBus(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/integration/service-bus.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *integrationContainer) ServiceCatalogManagedApplicationDefinitions(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/integration/service-catalog-managed-application-definitions.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *integrationContainer) SoftwareAsAService(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/integration/software-as-a-service.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *integrationContainer) StorsimpleDeviceManagers(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/integration/storsimple-device-managers.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }

--- a/nodes/azure/iot.go
+++ b/nodes/azure/iot.go
@@ -12,36 +12,6 @@ var Iot = &iotContainer{
 	path: "assets/azure/iot",
 }
 
-func (c *iotContainer) Windows10IotCoreServices(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/iot/windows-10-iot-core-services.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *iotContainer) IotHub(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/iot/iot-hub.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *iotContainer) Maps(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/iot/maps.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *iotContainer) TimeSeriesInsightsEnvironments(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/iot/time-series-insights-environments.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *iotContainer) TimeSeriesInsightsEventsSources(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/iot/time-series-insights-events-sources.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *iotContainer) Sphere(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/iot/sphere.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
 func (c *iotContainer) DeviceProvisioningServices(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/iot/device-provisioning-services.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
@@ -59,5 +29,35 @@ func (c *iotContainer) IotCentralApplications(opts ...diagram.NodeOption) *diagr
 
 func (c *iotContainer) IotHubSecurity(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/iot/iot-hub-security.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *iotContainer) IotHub(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/iot/iot-hub.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *iotContainer) Maps(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/iot/maps.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *iotContainer) Sphere(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/iot/sphere.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *iotContainer) TimeSeriesInsightsEnvironments(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/iot/time-series-insights-environments.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *iotContainer) TimeSeriesInsightsEventsSources(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/iot/time-series-insights-events-sources.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *iotContainer) Windows10IotCoreServices(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/iot/windows-10-iot-core-services.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }

--- a/nodes/azure/ml.go
+++ b/nodes/azure/ml.go
@@ -12,11 +12,6 @@ var Ml = &mlContainer{
 	path: "assets/azure/ml",
 }
 
-func (c *mlContainer) MachineLearningStudioWorkspaces(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/ml/machine-learning-studio-workspaces.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
 func (c *mlContainer) BatchAi(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/ml/batch-ai.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
@@ -49,5 +44,10 @@ func (c *mlContainer) MachineLearningStudioWebServicePlans(opts ...diagram.NodeO
 
 func (c *mlContainer) MachineLearningStudioWebServices(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/ml/machine-learning-studio-web-services.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *mlContainer) MachineLearningStudioWorkspaces(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/ml/machine-learning-studio-workspaces.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }

--- a/nodes/azure/network.go
+++ b/nodes/azure/network.go
@@ -12,73 +12,8 @@ var Network = &networkContainer{
 	path: "assets/azure/network",
 }
 
-func (c *networkContainer) VirtualWans(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/network/virtual-wans.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
 func (c *networkContainer) ApplicationGateway(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/network/application-gateway.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *networkContainer) FrontDoors(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/network/front-doors.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *networkContainer) LoadBalancers(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/network/load-balancers.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *networkContainer) NetworkInterfaces(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/network/network-interfaces.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *networkContainer) NetworkWatcher(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/network/network-watcher.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *networkContainer) RouteTables(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/network/route-tables.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *networkContainer) VirtualNetworkGateways(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/network/virtual-network-gateways.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *networkContainer) Connections(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/network/connections.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *networkContainer) DnsPrivateZones(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/network/dns-private-zones.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *networkContainer) DnsZones(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/network/dns-zones.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *networkContainer) NetworkSecurityGroupsClassic(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/network/network-security-groups-classic.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *networkContainer) OnPremisesDataGateways(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/network/on-premises-data-gateways.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *networkContainer) VirtualNetworks(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/network/virtual-networks.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }
 
@@ -92,28 +27,8 @@ func (c *networkContainer) CdnProfiles(opts ...diagram.NodeOption) *diagram.Node
 	return diagram.NewNode(nopts...)
 }
 
-func (c *networkContainer) ExpressrouteCircuits(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/network/expressroute-circuits.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *networkContainer) ServiceEndpointPolicies(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/network/service-endpoint-policies.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *networkContainer) VirtualNetworkClassic(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/network/virtual-network-classic.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *networkContainer) RouteFilters(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/network/route-filters.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *networkContainer) TrafficManagerProfiles(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/network/traffic-manager-profiles.png")}, c.opts, opts)
+func (c *networkContainer) Connections(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/network/connections.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }
 
@@ -122,13 +37,58 @@ func (c *networkContainer) DdosProtectionPlans(opts ...diagram.NodeOption) *diag
 	return diagram.NewNode(nopts...)
 }
 
+func (c *networkContainer) DnsPrivateZones(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/network/dns-private-zones.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *networkContainer) DnsZones(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/network/dns-zones.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *networkContainer) ExpressrouteCircuits(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/network/expressroute-circuits.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
 func (c *networkContainer) Firewall(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/network/firewall.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }
 
+func (c *networkContainer) FrontDoors(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/network/front-doors.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *networkContainer) LoadBalancers(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/network/load-balancers.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
 func (c *networkContainer) LocalNetworkGateways(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/network/local-network-gateways.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *networkContainer) NetworkInterfaces(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/network/network-interfaces.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *networkContainer) NetworkSecurityGroupsClassic(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/network/network-security-groups-classic.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *networkContainer) NetworkWatcher(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/network/network-watcher.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *networkContainer) OnPremisesDataGateways(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/network/on-premises-data-gateways.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }
 
@@ -139,5 +99,45 @@ func (c *networkContainer) PublicIpAddresses(opts ...diagram.NodeOption) *diagra
 
 func (c *networkContainer) ReservedIpAddressesClassic(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/network/reserved-ip-addresses-classic.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *networkContainer) RouteFilters(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/network/route-filters.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *networkContainer) RouteTables(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/network/route-tables.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *networkContainer) ServiceEndpointPolicies(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/network/service-endpoint-policies.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *networkContainer) TrafficManagerProfiles(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/network/traffic-manager-profiles.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *networkContainer) VirtualNetworkClassic(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/network/virtual-network-classic.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *networkContainer) VirtualNetworkGateways(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/network/virtual-network-gateways.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *networkContainer) VirtualNetworks(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/network/virtual-networks.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *networkContainer) VirtualWans(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/network/virtual-wans.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }

--- a/nodes/azure/storage.go
+++ b/nodes/azure/storage.go
@@ -12,33 +12,13 @@ var Storage = &storageContainer{
 	path: "assets/azure/storage",
 }
 
-func (c *storageContainer) Azurefxtedgefiler(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/storage/azurefxtedgefiler.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *storageContainer) DataBoxEdgeDataBoxGateway(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/storage/data-box-edge---data-box-gateway.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *storageContainer) NetappFiles(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/storage/netapp-files.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *storageContainer) TableStorage(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/storage/table-storage.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *storageContainer) StorsimpleDeviceManagers(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/storage/storsimple-device-managers.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
 func (c *storageContainer) ArchiveStorage(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/storage/archive-storage.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *storageContainer) Azurefxtedgefiler(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/storage/azurefxtedgefiler.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }
 
@@ -47,8 +27,33 @@ func (c *storageContainer) BlobStorage(opts ...diagram.NodeOption) *diagram.Node
 	return diagram.NewNode(nopts...)
 }
 
+func (c *storageContainer) DataBoxEdgeDataBoxGateway(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/storage/data-box-edge---data-box-gateway.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
 func (c *storageContainer) DataBox(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/storage/data-box.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *storageContainer) DataLakeStorage(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/storage/data-lake-storage.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *storageContainer) GeneralStorage(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/storage/general-storage.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *storageContainer) NetappFiles(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/storage/netapp-files.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *storageContainer) QueuesStorage(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/storage/queues-storage.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }
 
@@ -67,21 +72,6 @@ func (c *storageContainer) StorageExplorer(opts ...diagram.NodeOption) *diagram.
 	return diagram.NewNode(nopts...)
 }
 
-func (c *storageContainer) GeneralStorage(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/storage/general-storage.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *storageContainer) QueuesStorage(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/storage/queues-storage.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *storageContainer) DataLakeStorage(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/storage/data-lake-storage.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
 func (c *storageContainer) StorageSyncServices(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/storage/storage-sync-services.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
@@ -89,5 +79,15 @@ func (c *storageContainer) StorageSyncServices(opts ...diagram.NodeOption) *diag
 
 func (c *storageContainer) StorsimpleDataManagers(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/storage/storsimple-data-managers.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *storageContainer) StorsimpleDeviceManagers(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/storage/storsimple-device-managers.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *storageContainer) TableStorage(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/storage/table-storage.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }

--- a/nodes/azure/web.go
+++ b/nodes/azure/web.go
@@ -12,21 +12,6 @@ var Web = &webContainer{
 	path: "assets/azure/web",
 }
 
-func (c *webContainer) NotificationHubNamespaces(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/web/notification-hub-namespaces.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *webContainer) Search(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/web/search.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *webContainer) Signalr(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/web/signalr.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
 func (c *webContainer) ApiConnections(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/web/api-connections.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
@@ -42,11 +27,6 @@ func (c *webContainer) AppServiceDomains(opts ...diagram.NodeOption) *diagram.No
 	return diagram.NewNode(nopts...)
 }
 
-func (c *webContainer) AppServices(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/web/app-services.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
 func (c *webContainer) AppServiceEnvironments(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/web/app-service-environments.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
@@ -57,7 +37,27 @@ func (c *webContainer) AppServicePlans(opts ...diagram.NodeOption) *diagram.Node
 	return diagram.NewNode(nopts...)
 }
 
+func (c *webContainer) AppServices(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/web/app-services.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
 func (c *webContainer) MediaServices(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/web/media-services.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *webContainer) NotificationHubNamespaces(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/web/notification-hub-namespaces.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *webContainer) Search(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/web/search.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *webContainer) Signalr(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/azure/web/signalr.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }

--- a/nodes/elastic/elasticsearch.go
+++ b/nodes/elastic/elasticsearch.go
@@ -12,21 +12,6 @@ var Elasticsearch = &elasticsearchContainer{
 	path: "assets/elastic/elasticsearch",
 }
 
-func (c *elasticsearchContainer) Monitoring(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/elastic/elasticsearch/monitoring.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *elasticsearchContainer) SecuritySettings(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/elastic/elasticsearch/security-settings.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *elasticsearchContainer) Sql(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/elastic/elasticsearch/sql.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
 func (c *elasticsearchContainer) Alerting(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/elastic/elasticsearch/alerting.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
@@ -42,11 +27,6 @@ func (c *elasticsearchContainer) Elasticsearch(opts ...diagram.NodeOption) *diag
 	return diagram.NewNode(nopts...)
 }
 
-func (c *elasticsearchContainer) Maps(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/elastic/elasticsearch/maps.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
 func (c *elasticsearchContainer) Kibana(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/elastic/elasticsearch/kibana.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
@@ -59,5 +39,25 @@ func (c *elasticsearchContainer) Logstash(opts ...diagram.NodeOption) *diagram.N
 
 func (c *elasticsearchContainer) MachineLearning(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/elastic/elasticsearch/machine-learning.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *elasticsearchContainer) Maps(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/elastic/elasticsearch/maps.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *elasticsearchContainer) Monitoring(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/elastic/elasticsearch/monitoring.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *elasticsearchContainer) SecuritySettings(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/elastic/elasticsearch/security-settings.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *elasticsearchContainer) Sql(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/elastic/elasticsearch/sql.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }

--- a/nodes/elastic/orchestration.go
+++ b/nodes/elastic/orchestration.go
@@ -12,12 +12,12 @@ var Orchestration = &orchestrationContainer{
 	path: "assets/elastic/orchestration",
 }
 
-func (c *orchestrationContainer) Eck(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/elastic/orchestration/eck.png")}, c.opts, opts)
+func (c *orchestrationContainer) Ece(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/elastic/orchestration/ece.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }
 
-func (c *orchestrationContainer) Ece(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/elastic/orchestration/ece.png")}, c.opts, opts)
+func (c *orchestrationContainer) Eck(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/elastic/orchestration/eck.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }

--- a/nodes/firebase/grow.go
+++ b/nodes/firebase/grow.go
@@ -12,26 +12,6 @@ var Grow = &growContainer{
 	path: "assets/firebase/grow",
 }
 
-func (c *growContainer) Invites(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/firebase/grow/invites.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *growContainer) Messaging(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/firebase/grow/messaging.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *growContainer) Predictions(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/firebase/grow/predictions.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *growContainer) RemoteConfig(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/firebase/grow/remote-config.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
 func (c *growContainer) AbTesting(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/firebase/grow/ab-testing.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
@@ -49,5 +29,25 @@ func (c *growContainer) DynamicLinks(opts ...diagram.NodeOption) *diagram.Node {
 
 func (c *growContainer) InAppMessaging(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/firebase/grow/in-app-messaging.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *growContainer) Invites(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/firebase/grow/invites.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *growContainer) Messaging(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/firebase/grow/messaging.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *growContainer) Predictions(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/firebase/grow/predictions.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *growContainer) RemoteConfig(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/firebase/grow/remote-config.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }

--- a/nodes/firebase/quality.go
+++ b/nodes/firebase/quality.go
@@ -12,11 +12,6 @@ var Quality = &qualityContainer{
 	path: "assets/firebase/quality",
 }
 
-func (c *qualityContainer) TestLab(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/firebase/quality/test-lab.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
 func (c *qualityContainer) AppDistribution(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/firebase/quality/app-distribution.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
@@ -34,5 +29,10 @@ func (c *qualityContainer) Crashlytics(opts ...diagram.NodeOption) *diagram.Node
 
 func (c *qualityContainer) PerformanceMonitoring(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/firebase/quality/performance-monitoring.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *qualityContainer) TestLab(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/firebase/quality/test-lab.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }

--- a/nodes/gcp/analytics.go
+++ b/nodes/gcp/analytics.go
@@ -12,28 +12,13 @@ var Analytics = &analyticsContainer{
 	path: "assets/gcp/analytics",
 }
 
-func (c *analyticsContainer) Composer(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/gcp/analytics/composer.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *analyticsContainer) DataFusion(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/gcp/analytics/data-fusion.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *analyticsContainer) Datalab(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/gcp/analytics/datalab.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *analyticsContainer) Dataproc(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/gcp/analytics/dataproc.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
 func (c *analyticsContainer) Bigquery(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/gcp/analytics/bigquery.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *analyticsContainer) Composer(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/gcp/analytics/composer.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }
 
@@ -42,13 +27,28 @@ func (c *analyticsContainer) DataCatalog(opts ...diagram.NodeOption) *diagram.No
 	return diagram.NewNode(nopts...)
 }
 
+func (c *analyticsContainer) DataFusion(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/gcp/analytics/data-fusion.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
 func (c *analyticsContainer) Dataflow(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/gcp/analytics/dataflow.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }
 
+func (c *analyticsContainer) Datalab(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/gcp/analytics/datalab.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
 func (c *analyticsContainer) Dataprep(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/gcp/analytics/dataprep.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *analyticsContainer) Dataproc(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/gcp/analytics/dataproc.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }
 

--- a/nodes/gcp/compute.go
+++ b/nodes/gcp/compute.go
@@ -12,6 +12,16 @@ var Compute = &computeContainer{
 	path: "assets/gcp/compute",
 }
 
+func (c *computeContainer) AppEngine(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/gcp/compute/app-engine.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *computeContainer) ComputeEngine(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/gcp/compute/compute-engine.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
 func (c *computeContainer) ContainerOptimizedOs(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/gcp/compute/container-optimized-os.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
@@ -39,15 +49,5 @@ func (c *computeContainer) KubernetesEngine(opts ...diagram.NodeOption) *diagram
 
 func (c *computeContainer) Run(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/gcp/compute/run.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *computeContainer) AppEngine(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/gcp/compute/app-engine.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *computeContainer) ComputeEngine(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/gcp/compute/compute-engine.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }

--- a/nodes/gcp/database.go
+++ b/nodes/gcp/database.go
@@ -12,6 +12,11 @@ var Database = &databaseContainer{
 	path: "assets/gcp/database",
 }
 
+func (c *databaseContainer) Bigtable(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/gcp/database/bigtable.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
 func (c *databaseContainer) Datastore(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/gcp/database/datastore.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
@@ -34,10 +39,5 @@ func (c *databaseContainer) Spanner(opts ...diagram.NodeOption) *diagram.Node {
 
 func (c *databaseContainer) Sql(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/gcp/database/sql.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *databaseContainer) Bigtable(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/gcp/database/bigtable.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }

--- a/nodes/gcp/devtools.go
+++ b/nodes/gcp/devtools.go
@@ -12,18 +12,13 @@ var Devtools = &devtoolsContainer{
 	path: "assets/gcp/devtools",
 }
 
-func (c *devtoolsContainer) ContainerRegistry(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/gcp/devtools/container-registry.png")}, c.opts, opts)
+func (c *devtoolsContainer) Build(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/gcp/devtools/build.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }
 
-func (c *devtoolsContainer) IdePlugins(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/gcp/devtools/ide-plugins.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *devtoolsContainer) SourceRepositories(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/gcp/devtools/source-repositories.png")}, c.opts, opts)
+func (c *devtoolsContainer) CodeForIntellij(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/gcp/devtools/code-for-intellij.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }
 
@@ -32,23 +27,23 @@ func (c *devtoolsContainer) Code(opts ...diagram.NodeOption) *diagram.Node {
 	return diagram.NewNode(nopts...)
 }
 
+func (c *devtoolsContainer) ContainerRegistry(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/gcp/devtools/container-registry.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
 func (c *devtoolsContainer) GradleAppEnginePlugin(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/gcp/devtools/gradle-app-engine-plugin.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }
 
-func (c *devtoolsContainer) TestLab(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/gcp/devtools/test-lab.png")}, c.opts, opts)
+func (c *devtoolsContainer) IdePlugins(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/gcp/devtools/ide-plugins.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }
 
-func (c *devtoolsContainer) ToolsForVisualStudio(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/gcp/devtools/tools-for-visual-studio.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *devtoolsContainer) CodeForIntellij(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/gcp/devtools/code-for-intellij.png")}, c.opts, opts)
+func (c *devtoolsContainer) MavenAppEnginePlugin(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/gcp/devtools/maven-app-engine-plugin.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }
 
@@ -62,18 +57,8 @@ func (c *devtoolsContainer) Sdk(opts ...diagram.NodeOption) *diagram.Node {
 	return diagram.NewNode(nopts...)
 }
 
-func (c *devtoolsContainer) ToolsForPowershell(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/gcp/devtools/tools-for-powershell.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *devtoolsContainer) Build(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/gcp/devtools/build.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *devtoolsContainer) MavenAppEnginePlugin(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/gcp/devtools/maven-app-engine-plugin.png")}, c.opts, opts)
+func (c *devtoolsContainer) SourceRepositories(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/gcp/devtools/source-repositories.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }
 
@@ -82,7 +67,22 @@ func (c *devtoolsContainer) Tasks(opts ...diagram.NodeOption) *diagram.Node {
 	return diagram.NewNode(nopts...)
 }
 
+func (c *devtoolsContainer) TestLab(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/gcp/devtools/test-lab.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
 func (c *devtoolsContainer) ToolsForEclipse(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/gcp/devtools/tools-for-eclipse.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *devtoolsContainer) ToolsForPowershell(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/gcp/devtools/tools-for-powershell.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *devtoolsContainer) ToolsForVisualStudio(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/gcp/devtools/tools-for-visual-studio.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }

--- a/nodes/gcp/ml.go
+++ b/nodes/gcp/ml.go
@@ -12,8 +12,68 @@ var Ml = &mlContainer{
 	path: "assets/gcp/ml",
 }
 
+func (c *mlContainer) AdvancedSolutionsLab(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/gcp/ml/advanced-solutions-lab.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *mlContainer) AiHub(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/gcp/ml/ai-hub.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *mlContainer) AiPlatformDataLabelingService(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/gcp/ml/ai-platform-data-labeling-service.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *mlContainer) AiPlatform(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/gcp/ml/ai-platform.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *mlContainer) AutomlNaturalLanguage(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/gcp/ml/automl-natural-language.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *mlContainer) AutomlTables(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/gcp/ml/automl-tables.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *mlContainer) AutomlTranslation(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/gcp/ml/automl-translation.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *mlContainer) AutomlVideoIntelligence(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/gcp/ml/automl-video-intelligence.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *mlContainer) AutomlVision(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/gcp/ml/automl-vision.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *mlContainer) Automl(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/gcp/ml/automl.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *mlContainer) DialogFlowEnterpriseEdition(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/gcp/ml/dialog-flow-enterprise-edition.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
 func (c *mlContainer) InferenceApi(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/gcp/ml/inference-api.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *mlContainer) JobsApi(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/gcp/ml/jobs-api.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }
 
@@ -32,18 +92,8 @@ func (c *mlContainer) SpeechToText(opts ...diagram.NodeOption) *diagram.Node {
 	return diagram.NewNode(nopts...)
 }
 
-func (c *mlContainer) AdvancedSolutionsLab(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/gcp/ml/advanced-solutions-lab.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *mlContainer) AiHub(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/gcp/ml/ai-hub.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *mlContainer) Automl(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/gcp/ml/automl.png")}, c.opts, opts)
+func (c *mlContainer) TextToSpeech(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/gcp/ml/text-to-speech.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }
 
@@ -52,67 +102,17 @@ func (c *mlContainer) Tpu(opts ...diagram.NodeOption) *diagram.Node {
 	return diagram.NewNode(nopts...)
 }
 
-func (c *mlContainer) VideoIntelligenceApi(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/gcp/ml/video-intelligence-api.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *mlContainer) AiPlatform(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/gcp/ml/ai-platform.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *mlContainer) AutomlTranslation(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/gcp/ml/automl-translation.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *mlContainer) JobsApi(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/gcp/ml/jobs-api.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
 func (c *mlContainer) TranslationApi(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/gcp/ml/translation-api.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }
 
-func (c *mlContainer) AiPlatformDataLabelingService(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/gcp/ml/ai-platform-data-labeling-service.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *mlContainer) AutomlNaturalLanguage(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/gcp/ml/automl-natural-language.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *mlContainer) DialogFlowEnterpriseEdition(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/gcp/ml/dialog-flow-enterprise-edition.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *mlContainer) TextToSpeech(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/gcp/ml/text-to-speech.png")}, c.opts, opts)
+func (c *mlContainer) VideoIntelligenceApi(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/gcp/ml/video-intelligence-api.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }
 
 func (c *mlContainer) VisionApi(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/gcp/ml/vision-api.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *mlContainer) AutomlTables(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/gcp/ml/automl-tables.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *mlContainer) AutomlVideoIntelligence(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/gcp/ml/automl-video-intelligence.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *mlContainer) AutomlVision(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/gcp/ml/automl-vision.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }

--- a/nodes/gcp/network.go
+++ b/nodes/gcp/network.go
@@ -12,18 +12,8 @@ var Network = &networkContainer{
 	path: "assets/gcp/network",
 }
 
-func (c *networkContainer) LoadBalancing(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/gcp/network/load-balancing.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *networkContainer) TrafficDirector(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/gcp/network/traffic-director.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *networkContainer) Vpn(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/gcp/network/vpn.png")}, c.opts, opts)
+func (c *networkContainer) Armor(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/gcp/network/armor.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }
 
@@ -42,6 +32,21 @@ func (c *networkContainer) Dns(opts ...diagram.NodeOption) *diagram.Node {
 	return diagram.NewNode(nopts...)
 }
 
+func (c *networkContainer) ExternalIpAddresses(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/gcp/network/external-ip-addresses.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *networkContainer) FirewallRules(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/gcp/network/firewall-rules.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *networkContainer) LoadBalancing(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/gcp/network/load-balancing.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
 func (c *networkContainer) Nat(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/gcp/network/nat.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
@@ -57,33 +62,13 @@ func (c *networkContainer) PartnerInterconnect(opts ...diagram.NodeOption) *diag
 	return diagram.NewNode(nopts...)
 }
 
-func (c *networkContainer) Router(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/gcp/network/router.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *networkContainer) StandardNetworkTier(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/gcp/network/standard-network-tier.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *networkContainer) Armor(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/gcp/network/armor.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *networkContainer) ExternalIpAddresses(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/gcp/network/external-ip-addresses.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *networkContainer) FirewallRules(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/gcp/network/firewall-rules.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
 func (c *networkContainer) PremiumNetworkTier(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/gcp/network/premium-network-tier.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *networkContainer) Router(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/gcp/network/router.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }
 
@@ -92,7 +77,22 @@ func (c *networkContainer) Routes(opts ...diagram.NodeOption) *diagram.Node {
 	return diagram.NewNode(nopts...)
 }
 
+func (c *networkContainer) StandardNetworkTier(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/gcp/network/standard-network-tier.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *networkContainer) TrafficDirector(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/gcp/network/traffic-director.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
 func (c *networkContainer) VirtualPrivateCloud(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/gcp/network/virtual-private-cloud.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *networkContainer) Vpn(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/gcp/network/vpn.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }

--- a/nodes/gcp/security.go
+++ b/nodes/gcp/security.go
@@ -12,6 +12,11 @@ var Security = &securityContainer{
 	path: "assets/gcp/security",
 }
 
+func (c *securityContainer) Iam(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/gcp/security/iam.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
 func (c *securityContainer) Iap(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/gcp/security/iap.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
@@ -34,10 +39,5 @@ func (c *securityContainer) SecurityCommandCenter(opts ...diagram.NodeOption) *d
 
 func (c *securityContainer) SecurityScanner(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/gcp/security/security-scanner.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *securityContainer) Iam(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/gcp/security/iam.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }

--- a/nodes/generic/os.go
+++ b/nodes/generic/os.go
@@ -12,16 +12,6 @@ var Os = &osContainer{
 	path: "assets/generic/os",
 }
 
-func (c *osContainer) Ubuntu(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/generic/os/ubuntu.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *osContainer) Windows(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/generic/os/windows.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
 func (c *osContainer) Android(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/generic/os/android.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
@@ -44,5 +34,15 @@ func (c *osContainer) LinuxGeneral(opts ...diagram.NodeOption) *diagram.Node {
 
 func (c *osContainer) Suse(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/generic/os/suse.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *osContainer) Ubuntu(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/generic/os/ubuntu.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *osContainer) Windows(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/generic/os/windows.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }

--- a/nodes/k8s/podconfig.go
+++ b/nodes/k8s/podconfig.go
@@ -12,12 +12,12 @@ var Podconfig = &podconfigContainer{
 	path: "assets/k8s/podconfig",
 }
 
-func (c *podconfigContainer) Secret(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/k8s/podconfig/secret.png")}, c.opts, opts)
+func (c *podconfigContainer) Cm(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/k8s/podconfig/cm.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }
 
-func (c *podconfigContainer) Cm(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/k8s/podconfig/cm.png")}, c.opts, opts)
+func (c *podconfigContainer) Secret(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/k8s/podconfig/secret.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }

--- a/nodes/k8s/rbac.go
+++ b/nodes/k8s/rbac.go
@@ -12,21 +12,6 @@ var Rbac = &rbacContainer{
 	path: "assets/k8s/rbac",
 }
 
-func (c *rbacContainer) Role(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/k8s/rbac/role.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *rbacContainer) Sa(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/k8s/rbac/sa.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *rbacContainer) User(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/k8s/rbac/user.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
 func (c *rbacContainer) CRole(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/k8s/rbac/c-role.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
@@ -44,5 +29,20 @@ func (c *rbacContainer) Group(opts ...diagram.NodeOption) *diagram.Node {
 
 func (c *rbacContainer) Rb(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/k8s/rbac/rb.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *rbacContainer) Role(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/k8s/rbac/role.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *rbacContainer) Sa(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/k8s/rbac/sa.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *rbacContainer) User(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/k8s/rbac/user.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }

--- a/nodes/k8s/storage.go
+++ b/nodes/k8s/storage.go
@@ -12,11 +12,6 @@ var Storage = &storageContainer{
 	path: "assets/k8s/storage",
 }
 
-func (c *storageContainer) Vol(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/k8s/storage/vol.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
 func (c *storageContainer) Pv(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/k8s/storage/pv.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
@@ -29,5 +24,10 @@ func (c *storageContainer) Pvc(opts ...diagram.NodeOption) *diagram.Node {
 
 func (c *storageContainer) Sc(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/k8s/storage/sc.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *storageContainer) Vol(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/k8s/storage/vol.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }

--- a/nodes/oci/compute.go
+++ b/nodes/oci/compute.go
@@ -12,26 +12,6 @@ var Compute = &computeContainer{
 	path: "assets/oci/compute",
 }
 
-func (c *computeContainer) Bm(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/compute/bm.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *computeContainer) Container(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/compute/container.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *computeContainer) Ocir(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/compute/ocir.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *computeContainer) Oke(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/compute/oke.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
 func (c *computeContainer) AutoscaleWhite(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/compute/autoscale-white.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
@@ -42,13 +22,23 @@ func (c *computeContainer) Autoscale(opts ...diagram.NodeOption) *diagram.Node {
 	return diagram.NewNode(nopts...)
 }
 
-func (c *computeContainer) Functions(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/compute/functions.png")}, c.opts, opts)
+func (c *computeContainer) BmWhite(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/compute/bm-white.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }
 
-func (c *computeContainer) OcirWhite(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/compute/ocir-white.png")}, c.opts, opts)
+func (c *computeContainer) Bm(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/compute/bm.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *computeContainer) ContainerWhite(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/compute/container-white.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *computeContainer) Container(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/compute/container.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }
 
@@ -57,8 +47,38 @@ func (c *computeContainer) FunctionsWhite(opts ...diagram.NodeOption) *diagram.N
 	return diagram.NewNode(nopts...)
 }
 
+func (c *computeContainer) Functions(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/compute/functions.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *computeContainer) InstancePoolsWhite(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/compute/instance-pools-white.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
 func (c *computeContainer) InstancePools(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/compute/instance-pools.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *computeContainer) OcirWhite(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/compute/ocir-white.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *computeContainer) Ocir(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/compute/ocir.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *computeContainer) OkeWhite(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/compute/oke-white.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *computeContainer) Oke(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/compute/oke.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }
 
@@ -69,25 +89,5 @@ func (c *computeContainer) VmWhite(opts ...diagram.NodeOption) *diagram.Node {
 
 func (c *computeContainer) Vm(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/compute/vm.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *computeContainer) BmWhite(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/compute/bm-white.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *computeContainer) ContainerWhite(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/compute/container-white.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *computeContainer) InstancePoolsWhite(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/compute/instance-pools-white.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *computeContainer) OkeWhite(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/compute/oke-white.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }

--- a/nodes/oci/connectivity.go
+++ b/nodes/oci/connectivity.go
@@ -12,53 +12,8 @@ var Connectivity = &connectivityContainer{
 	path: "assets/oci/connectivity",
 }
 
-func (c *connectivityContainer) Dns(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/connectivity/dns.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *connectivityContainer) DisconnectedRegions(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/connectivity/disconnected-regions.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *connectivityContainer) CustomerPremise(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/connectivity/customer-premise.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *connectivityContainer) CustomerDatacntrWhite(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/connectivity/customer-datacntr-white.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *connectivityContainer) CustomerPremiseWhite(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/connectivity/customer-premise-white.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *connectivityContainer) DnsWhite(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/connectivity/dns-white.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *connectivityContainer) FastConnectWhite(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/connectivity/fast-connect-white.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *connectivityContainer) NatGateway(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/connectivity/nat-gateway.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *connectivityContainer) Vpn(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/connectivity/vpn.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *connectivityContainer) CustomerDatacenter(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/connectivity/customer-datacenter.png")}, c.opts, opts)
+func (c *connectivityContainer) BackboneWhite(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/connectivity/backbone-white.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }
 
@@ -77,8 +32,48 @@ func (c *connectivityContainer) Cdn(opts ...diagram.NodeOption) *diagram.Node {
 	return diagram.NewNode(nopts...)
 }
 
+func (c *connectivityContainer) CustomerDatacenter(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/connectivity/customer-datacenter.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *connectivityContainer) CustomerDatacntrWhite(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/connectivity/customer-datacntr-white.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *connectivityContainer) CustomerPremiseWhite(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/connectivity/customer-premise-white.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *connectivityContainer) CustomerPremise(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/connectivity/customer-premise.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
 func (c *connectivityContainer) DisconnectedRegionsWhite(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/connectivity/disconnected-regions-white.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *connectivityContainer) DisconnectedRegions(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/connectivity/disconnected-regions.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *connectivityContainer) DnsWhite(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/connectivity/dns-white.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *connectivityContainer) Dns(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/connectivity/dns.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *connectivityContainer) FastConnectWhite(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/connectivity/fast-connect-white.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }
 
@@ -92,12 +87,17 @@ func (c *connectivityContainer) NatGatewayWhite(opts ...diagram.NodeOption) *dia
 	return diagram.NewNode(nopts...)
 }
 
+func (c *connectivityContainer) NatGateway(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/connectivity/nat-gateway.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
 func (c *connectivityContainer) VpnWhite(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/connectivity/vpn-white.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }
 
-func (c *connectivityContainer) BackboneWhite(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/connectivity/backbone-white.png")}, c.opts, opts)
+func (c *connectivityContainer) Vpn(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/connectivity/vpn.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }

--- a/nodes/oci/database.go
+++ b/nodes/oci/database.go
@@ -12,46 +12,6 @@ var Database = &databaseContainer{
 	path: "assets/oci/database",
 }
 
-func (c *databaseContainer) DcatWhite(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/database/dcat-white.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *databaseContainer) DisWhite(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/database/dis-white.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *databaseContainer) Dms(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/database/dms.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *databaseContainer) ScienceWhite(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/database/science-white.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *databaseContainer) StreamWhite(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/database/stream-white.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *databaseContainer) BigdataServiceWhite(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/database/bigdata-service-white.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *databaseContainer) Science(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/database/science.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *databaseContainer) Stream(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/database/stream.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
 func (c *databaseContainer) AutonomousWhite(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/database/autonomous-white.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
@@ -62,23 +22,8 @@ func (c *databaseContainer) Autonomous(opts ...diagram.NodeOption) *diagram.Node
 	return diagram.NewNode(nopts...)
 }
 
-func (c *databaseContainer) DatabaseService(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/database/database-service.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *databaseContainer) DataflowApacheWhite(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/database/dataflow-apache-white.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *databaseContainer) Dis(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/database/dis.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *databaseContainer) DmsWhite(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/database/dms-white.png")}, c.opts, opts)
+func (c *databaseContainer) BigdataServiceWhite(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/database/bigdata-service-white.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }
 
@@ -92,12 +37,67 @@ func (c *databaseContainer) DatabaseServiceWhite(opts ...diagram.NodeOption) *di
 	return diagram.NewNode(nopts...)
 }
 
+func (c *databaseContainer) DatabaseService(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/database/database-service.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *databaseContainer) DataflowApacheWhite(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/database/dataflow-apache-white.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
 func (c *databaseContainer) DataflowApache(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/database/dataflow-apache.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }
 
+func (c *databaseContainer) DcatWhite(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/database/dcat-white.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
 func (c *databaseContainer) Dcat(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/database/dcat.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *databaseContainer) DisWhite(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/database/dis-white.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *databaseContainer) Dis(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/database/dis.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *databaseContainer) DmsWhite(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/database/dms-white.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *databaseContainer) Dms(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/database/dms.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *databaseContainer) ScienceWhite(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/database/science-white.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *databaseContainer) Science(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/database/science.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *databaseContainer) StreamWhite(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/database/stream-white.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *databaseContainer) Stream(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/database/stream.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }

--- a/nodes/oci/devops.go
+++ b/nodes/oci/devops.go
@@ -12,11 +12,6 @@ var Devops = &devopsContainer{
 	path: "assets/oci/devops",
 }
 
-func (c *devopsContainer) ResourceMgmt(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/devops/resource-mgmt.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
 func (c *devopsContainer) ApiGatewayWhite(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/devops/api-gateway-white.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
@@ -39,5 +34,10 @@ func (c *devopsContainer) ApiService(opts ...diagram.NodeOption) *diagram.Node {
 
 func (c *devopsContainer) ResourceMgmtWhite(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/devops/resource-mgmt-white.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *devopsContainer) ResourceMgmt(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/devops/resource-mgmt.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }

--- a/nodes/oci/governance.go
+++ b/nodes/oci/governance.go
@@ -12,18 +12,13 @@ var Governance = &governanceContainer{
 	path: "assets/oci/governance",
 }
 
-func (c *governanceContainer) Groups(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/governance/groups.png")}, c.opts, opts)
+func (c *governanceContainer) AuditWhite(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/governance/audit-white.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }
 
-func (c *governanceContainer) PoliciesWhite(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/governance/policies-white.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *governanceContainer) Tagging(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/governance/tagging.png")}, c.opts, opts)
+func (c *governanceContainer) Audit(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/governance/audit.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }
 
@@ -37,8 +32,38 @@ func (c *governanceContainer) Compartments(opts ...diagram.NodeOption) *diagram.
 	return diagram.NewNode(nopts...)
 }
 
+func (c *governanceContainer) GroupsWhite(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/governance/groups-white.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *governanceContainer) Groups(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/governance/groups.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *governanceContainer) LoggingWhite(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/governance/logging-white.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *governanceContainer) Logging(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/governance/logging.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *governanceContainer) OcidWhite(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/governance/ocid-white.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
 func (c *governanceContainer) Ocid(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/governance/ocid.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *governanceContainer) PoliciesWhite(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/governance/policies-white.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }
 
@@ -52,32 +77,7 @@ func (c *governanceContainer) TaggingWhite(opts ...diagram.NodeOption) *diagram.
 	return diagram.NewNode(nopts...)
 }
 
-func (c *governanceContainer) AuditWhite(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/governance/audit-white.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *governanceContainer) Logging(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/governance/logging.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *governanceContainer) Audit(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/governance/audit.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *governanceContainer) GroupsWhite(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/governance/groups-white.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *governanceContainer) LoggingWhite(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/governance/logging-white.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *governanceContainer) OcidWhite(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/governance/ocid-white.png")}, c.opts, opts)
+func (c *governanceContainer) Tagging(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/governance/tagging.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }

--- a/nodes/oci/monitoring.go
+++ b/nodes/oci/monitoring.go
@@ -12,6 +12,11 @@ var Monitoring = &monitoringContainer{
 	path: "assets/oci/monitoring",
 }
 
+func (c *monitoringContainer) AlarmWhite(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/monitoring/alarm-white.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
 func (c *monitoringContainer) Alarm(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/monitoring/alarm.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
@@ -19,41 +24,6 @@ func (c *monitoringContainer) Alarm(opts ...diagram.NodeOption) *diagram.Node {
 
 func (c *monitoringContainer) EmailWhite(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/monitoring/email-white.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *monitoringContainer) NotificationsWhite(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/monitoring/notifications-white.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *monitoringContainer) QueueWhite(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/monitoring/queue-white.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *monitoringContainer) WorkflowWhite(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/monitoring/workflow-white.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *monitoringContainer) HealthCheckWhite(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/monitoring/health-check-white.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *monitoringContainer) Notifications(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/monitoring/notifications.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *monitoringContainer) TelemetryWhite(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/monitoring/telemetry-white.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *monitoringContainer) AlarmWhite(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/monitoring/alarm-white.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }
 
@@ -67,6 +37,41 @@ func (c *monitoringContainer) EventsWhite(opts ...diagram.NodeOption) *diagram.N
 	return diagram.NewNode(nopts...)
 }
 
+func (c *monitoringContainer) Events(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/monitoring/events.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *monitoringContainer) HealthCheckWhite(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/monitoring/health-check-white.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *monitoringContainer) HealthCheck(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/monitoring/health-check.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *monitoringContainer) NotificationsWhite(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/monitoring/notifications-white.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *monitoringContainer) Notifications(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/monitoring/notifications.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *monitoringContainer) QueueWhite(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/monitoring/queue-white.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *monitoringContainer) Queue(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/monitoring/queue.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
 func (c *monitoringContainer) SearchWhite(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/monitoring/search-white.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
@@ -77,27 +82,22 @@ func (c *monitoringContainer) Search(opts ...diagram.NodeOption) *diagram.Node {
 	return diagram.NewNode(nopts...)
 }
 
+func (c *monitoringContainer) TelemetryWhite(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/monitoring/telemetry-white.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
 func (c *monitoringContainer) Telemetry(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/monitoring/telemetry.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }
 
+func (c *monitoringContainer) WorkflowWhite(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/monitoring/workflow-white.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
 func (c *monitoringContainer) Workflow(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/monitoring/workflow.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *monitoringContainer) Events(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/monitoring/events.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *monitoringContainer) HealthCheck(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/monitoring/health-check.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *monitoringContainer) Queue(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/monitoring/queue.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }

--- a/nodes/oci/network.go
+++ b/nodes/oci/network.go
@@ -12,13 +12,13 @@ var Network = &networkContainer{
 	path: "assets/oci/network",
 }
 
-func (c *networkContainer) InternetGateway(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/network/internet-gateway.png")}, c.opts, opts)
+func (c *networkContainer) DrgWhite(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/network/drg-white.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }
 
-func (c *networkContainer) Vcn(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/network/vcn.png")}, c.opts, opts)
+func (c *networkContainer) Drg(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/network/drg.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }
 
@@ -37,33 +37,8 @@ func (c *networkContainer) InternetGatewayWhite(opts ...diagram.NodeOption) *dia
 	return diagram.NewNode(nopts...)
 }
 
-func (c *networkContainer) LoadBalancer(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/network/load-balancer.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *networkContainer) SecurityLists(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/network/security-lists.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *networkContainer) ServiceGatewayWhite(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/network/service-gateway-white.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *networkContainer) VcnWhite(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/network/vcn-white.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *networkContainer) DrgWhite(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/network/drg-white.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *networkContainer) Drg(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/network/drg.png")}, c.opts, opts)
+func (c *networkContainer) InternetGateway(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/network/internet-gateway.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }
 
@@ -72,8 +47,8 @@ func (c *networkContainer) LoadBalancerWhite(opts ...diagram.NodeOption) *diagra
 	return diagram.NewNode(nopts...)
 }
 
-func (c *networkContainer) ServiceGateway(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/network/service-gateway.png")}, c.opts, opts)
+func (c *networkContainer) LoadBalancer(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/network/load-balancer.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }
 
@@ -89,5 +64,30 @@ func (c *networkContainer) RouteTable(opts ...diagram.NodeOption) *diagram.Node 
 
 func (c *networkContainer) SecurityListsWhite(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/network/security-lists-white.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *networkContainer) SecurityLists(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/network/security-lists.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *networkContainer) ServiceGatewayWhite(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/network/service-gateway-white.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *networkContainer) ServiceGateway(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/network/service-gateway.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *networkContainer) VcnWhite(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/network/vcn-white.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *networkContainer) Vcn(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/network/vcn.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }

--- a/nodes/oci/security.go
+++ b/nodes/oci/security.go
@@ -12,33 +12,8 @@ var Security = &securityContainer{
 	path: "assets/oci/security",
 }
 
-func (c *securityContainer) Encryption(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/security/encryption.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *securityContainer) MaxSecurityZoneWhite(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/security/max-security-zone-white.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
 func (c *securityContainer) CloudGuardWhite(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/security/cloud-guard-white.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *securityContainer) DdosWhite(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/security/ddos-white.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *securityContainer) EncryptionWhite(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/security/encryption-white.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *securityContainer) Waf(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/security/waf.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }
 
@@ -47,28 +22,23 @@ func (c *securityContainer) CloudGuard(opts ...diagram.NodeOption) *diagram.Node
 	return diagram.NewNode(nopts...)
 }
 
+func (c *securityContainer) DdosWhite(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/security/ddos-white.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
 func (c *securityContainer) Ddos(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/security/ddos.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }
 
-func (c *securityContainer) Vault(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/security/vault.png")}, c.opts, opts)
+func (c *securityContainer) EncryptionWhite(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/security/encryption-white.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }
 
-func (c *securityContainer) MaxSecurityZone(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/security/max-security-zone.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *securityContainer) VaultWhite(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/security/vault-white.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *securityContainer) WafWhite(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/security/waf-white.png")}, c.opts, opts)
+func (c *securityContainer) Encryption(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/security/encryption.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }
 
@@ -89,5 +59,35 @@ func (c *securityContainer) KeyManagementWhite(opts ...diagram.NodeOption) *diag
 
 func (c *securityContainer) KeyManagement(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/security/key-management.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *securityContainer) MaxSecurityZoneWhite(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/security/max-security-zone-white.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *securityContainer) MaxSecurityZone(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/security/max-security-zone.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *securityContainer) VaultWhite(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/security/vault-white.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *securityContainer) Vault(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/security/vault.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *securityContainer) WafWhite(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/security/waf-white.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *securityContainer) Waf(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/security/waf.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }

--- a/nodes/oci/storage.go
+++ b/nodes/oci/storage.go
@@ -12,33 +12,8 @@ var Storage = &storageContainer{
 	path: "assets/oci/storage",
 }
 
-func (c *storageContainer) BlockStorageCloneWhite(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/storage/block-storage-clone-white.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *storageContainer) BlockStorageWhite(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/storage/block-storage-white.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *storageContainer) BucketsWhite(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/storage/buckets-white.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *storageContainer) ObjectStorageWhite(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/storage/object-storage-white.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *storageContainer) ObjectStorage(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/storage/object-storage.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *storageContainer) StorageGatewayWhite(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/storage/storage-gateway-white.png")}, c.opts, opts)
+func (c *storageContainer) BackupRestoreWhite(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/storage/backup-restore-white.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }
 
@@ -47,33 +22,38 @@ func (c *storageContainer) BackupRestore(opts ...diagram.NodeOption) *diagram.No
 	return diagram.NewNode(nopts...)
 }
 
-func (c *storageContainer) DataTransferWhite(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/storage/data-transfer-white.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *storageContainer) FileStorageWhite(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/storage/file-storage-white.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *storageContainer) FileStorage(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/storage/file-storage.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *storageContainer) StorageGateway(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/storage/storage-gateway.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *storageContainer) BackupRestoreWhite(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/storage/backup-restore-white.png")}, c.opts, opts)
+func (c *storageContainer) BlockStorageCloneWhite(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/storage/block-storage-clone-white.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }
 
 func (c *storageContainer) BlockStorageClone(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/storage/block-storage-clone.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *storageContainer) BlockStorageWhite(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/storage/block-storage-white.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *storageContainer) BlockStorage(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/storage/block-storage.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *storageContainer) BucketsWhite(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/storage/buckets-white.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *storageContainer) Buckets(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/storage/buckets.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *storageContainer) DataTransferWhite(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/storage/data-transfer-white.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }
 
@@ -92,12 +72,32 @@ func (c *storageContainer) ElasticPerformance(opts ...diagram.NodeOption) *diagr
 	return diagram.NewNode(nopts...)
 }
 
-func (c *storageContainer) BlockStorage(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/storage/block-storage.png")}, c.opts, opts)
+func (c *storageContainer) FileStorageWhite(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/storage/file-storage-white.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }
 
-func (c *storageContainer) Buckets(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/storage/buckets.png")}, c.opts, opts)
+func (c *storageContainer) FileStorage(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/storage/file-storage.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *storageContainer) ObjectStorageWhite(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/storage/object-storage-white.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *storageContainer) ObjectStorage(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/storage/object-storage.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *storageContainer) StorageGatewayWhite(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/storage/storage-gateway-white.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *storageContainer) StorageGateway(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/oci/storage/storage-gateway.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }

--- a/nodes/openstack/applicationlifecycle.go
+++ b/nodes/openstack/applicationlifecycle.go
@@ -12,16 +12,6 @@ var Applicationlifecycle = &applicationlifecycleContainer{
 	path: "assets/openstack/applicationlifecycle",
 }
 
-func (c *applicationlifecycleContainer) Murano(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/openstack/applicationlifecycle/murano.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *applicationlifecycleContainer) Solum(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/openstack/applicationlifecycle/solum.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
 func (c *applicationlifecycleContainer) Freezer(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/openstack/applicationlifecycle/freezer.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
@@ -29,5 +19,15 @@ func (c *applicationlifecycleContainer) Freezer(opts ...diagram.NodeOption) *dia
 
 func (c *applicationlifecycleContainer) Masakari(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/openstack/applicationlifecycle/masakari.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *applicationlifecycleContainer) Murano(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/openstack/applicationlifecycle/murano.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *applicationlifecycleContainer) Solum(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/openstack/applicationlifecycle/solum.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }

--- a/nodes/openstack/compute.go
+++ b/nodes/openstack/compute.go
@@ -12,6 +12,11 @@ var Compute = &computeContainer{
 	path: "assets/openstack/compute",
 }
 
+func (c *computeContainer) Nova(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/openstack/compute/nova.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
 func (c *computeContainer) Qinling(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/openstack/compute/qinling.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
@@ -19,10 +24,5 @@ func (c *computeContainer) Qinling(opts ...diagram.NodeOption) *diagram.Node {
 
 func (c *computeContainer) Zun(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/openstack/compute/zun.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *computeContainer) Nova(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/openstack/compute/nova.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }

--- a/nodes/openstack/deployment.go
+++ b/nodes/openstack/deployment.go
@@ -12,16 +12,6 @@ var Deployment = &deploymentContainer{
 	path: "assets/openstack/deployment",
 }
 
-func (c *deploymentContainer) Kolla(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/openstack/lifecyclemanagement/deployment/kolla.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *deploymentContainer) Tripleo(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/openstack/lifecyclemanagement/deployment/tripleo.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
 func (c *deploymentContainer) Ansible(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/openstack/lifecyclemanagement/deployment/ansible.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
@@ -39,5 +29,15 @@ func (c *deploymentContainer) Chef(opts ...diagram.NodeOption) *diagram.Node {
 
 func (c *deploymentContainer) Helm(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/openstack/lifecyclemanagement/deployment/helm.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *deploymentContainer) Kolla(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/openstack/lifecyclemanagement/deployment/kolla.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *deploymentContainer) Tripleo(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/openstack/lifecyclemanagement/deployment/tripleo.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }

--- a/nodes/openstack/orchestration.go
+++ b/nodes/openstack/orchestration.go
@@ -12,11 +12,6 @@ var Orchestration = &orchestrationContainer{
 	path: "assets/openstack/orchestration",
 }
 
-func (c *orchestrationContainer) Zaqar(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/openstack/orchestration/zaqar.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
 func (c *orchestrationContainer) Blazar(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/openstack/orchestration/blazar.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
@@ -34,5 +29,10 @@ func (c *orchestrationContainer) Mistral(opts ...diagram.NodeOption) *diagram.No
 
 func (c *orchestrationContainer) Senlin(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/openstack/orchestration/senlin.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *orchestrationContainer) Zaqar(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/openstack/orchestration/zaqar.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }

--- a/nodes/openstack/packaging.go
+++ b/nodes/openstack/packaging.go
@@ -12,6 +12,11 @@ var Packaging = &packagingContainer{
 	path: "assets/openstack/packaging",
 }
 
+func (c *packagingContainer) Loci(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/openstack/lifecyclemanagement/packaging/loci.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
 func (c *packagingContainer) Puppet(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/openstack/lifecyclemanagement/packaging/puppet.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
@@ -19,10 +24,5 @@ func (c *packagingContainer) Puppet(opts ...diagram.NodeOption) *diagram.Node {
 
 func (c *packagingContainer) Rpm(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/openstack/lifecyclemanagement/packaging/rpm.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *packagingContainer) Loci(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/openstack/lifecyclemanagement/packaging/loci.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }

--- a/nodes/outscale/network.go
+++ b/nodes/outscale/network.go
@@ -12,6 +12,11 @@ var Network = &networkContainer{
 	path: "assets/outscale/network",
 }
 
+func (c *networkContainer) ClientVpn(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/outscale/network/client-vpn.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
 func (c *networkContainer) InternetService(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/outscale/network/internet-service.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
@@ -34,10 +39,5 @@ func (c *networkContainer) Net(opts ...diagram.NodeOption) *diagram.Node {
 
 func (c *networkContainer) SiteToSiteVpng(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/outscale/network/site-to-site-vpng.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *networkContainer) ClientVpn(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/outscale/network/client-vpn.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }

--- a/nodes/programming/framework.go
+++ b/nodes/programming/framework.go
@@ -12,6 +12,11 @@ var Framework = &frameworkContainer{
 	path: "assets/programming/framework",
 }
 
+func (c *frameworkContainer) Angular(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/programming/framework/angular.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
 func (c *frameworkContainer) Backbone(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/programming/framework/backbone.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
@@ -19,6 +24,16 @@ func (c *frameworkContainer) Backbone(opts ...diagram.NodeOption) *diagram.Node 
 
 func (c *frameworkContainer) Django(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/programming/framework/django.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *frameworkContainer) Ember(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/programming/framework/ember.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *frameworkContainer) Flask(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/programming/framework/flask.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }
 
@@ -32,26 +47,6 @@ func (c *frameworkContainer) Laravel(opts ...diagram.NodeOption) *diagram.Node {
 	return diagram.NewNode(nopts...)
 }
 
-func (c *frameworkContainer) Spring(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/programming/framework/spring.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *frameworkContainer) Vue(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/programming/framework/vue.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *frameworkContainer) Angular(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/programming/framework/angular.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *frameworkContainer) Flask(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/programming/framework/flask.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
 func (c *frameworkContainer) Rails(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/programming/framework/rails.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
@@ -62,7 +57,12 @@ func (c *frameworkContainer) React(opts ...diagram.NodeOption) *diagram.Node {
 	return diagram.NewNode(nopts...)
 }
 
-func (c *frameworkContainer) Ember(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/programming/framework/ember.png")}, c.opts, opts)
+func (c *frameworkContainer) Spring(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/programming/framework/spring.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *frameworkContainer) Vue(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/programming/framework/vue.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }

--- a/nodes/programming/language.go
+++ b/nodes/programming/language.go
@@ -12,8 +12,38 @@ var Language = &languageContainer{
 	path: "assets/programming/language",
 }
 
+func (c *languageContainer) Bash(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/programming/language/bash.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *languageContainer) C(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/programming/language/c.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *languageContainer) Cpp(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/programming/language/cpp.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
 func (c *languageContainer) Csharp(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/programming/language/csharp.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *languageContainer) Dart(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/programming/language/dart.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *languageContainer) Go(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/programming/language/go.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *languageContainer) Java(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/programming/language/java.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }
 
@@ -32,43 +62,13 @@ func (c *languageContainer) Matlab(opts ...diagram.NodeOption) *diagram.Node {
 	return diagram.NewNode(nopts...)
 }
 
-func (c *languageContainer) Php(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/programming/language/php.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *languageContainer) Typescript(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/programming/language/typescript.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *languageContainer) Rust(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/programming/language/rust.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *languageContainer) Bash(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/programming/language/bash.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *languageContainer) C(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/programming/language/c.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *languageContainer) Cpp(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/programming/language/cpp.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *languageContainer) Dart(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/programming/language/dart.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
 func (c *languageContainer) Nodejs(opts ...diagram.NodeOption) *diagram.Node {
 	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/programming/language/nodejs.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *languageContainer) Php(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/programming/language/php.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }
 
@@ -82,8 +82,13 @@ func (c *languageContainer) R(opts ...diagram.NodeOption) *diagram.Node {
 	return diagram.NewNode(nopts...)
 }
 
-func (c *languageContainer) Java(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/programming/language/java.png")}, c.opts, opts)
+func (c *languageContainer) Ruby(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/programming/language/ruby.png")}, c.opts, opts)
+	return diagram.NewNode(nopts...)
+}
+
+func (c *languageContainer) Rust(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/programming/language/rust.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }
 
@@ -92,12 +97,7 @@ func (c *languageContainer) Swift(opts ...diagram.NodeOption) *diagram.Node {
 	return diagram.NewNode(nopts...)
 }
 
-func (c *languageContainer) Go(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/programming/language/go.png")}, c.opts, opts)
-	return diagram.NewNode(nopts...)
-}
-
-func (c *languageContainer) Ruby(opts ...diagram.NodeOption) *diagram.Node {
-	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/programming/language/ruby.png")}, c.opts, opts)
+func (c *languageContainer) Typescript(opts ...diagram.NodeOption) *diagram.Node {
+	nopts := diagram.MergeOptionSets(diagram.OptionSet{diagram.Icon("assets/programming/language/typescript.png")}, c.opts, opts)
 	return diagram.NewNode(nopts...)
 }


### PR DESCRIPTION
I found that the generation utility wasn't giving consistent ordering -- this would mean any re-generation would show much more change than accurate.  This makes review difficult, which impacts attempts to work as a group.

A simple ordering of keys and traversal in order resolves.

Generated results show both re-ordering of existing, plus any new assets not yet generated.